### PR TITLE
feat: update rules for Claude Code 2.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ claude
 | `~/.claude/settings.json` | Claude Code settings |
 | `~/.claude/mcp-global.json` | MCP server configuration |
 
+### Claude Code 2.1.x Features Used
+| Feature | Purpose |
+|---------|---------|
+| Task subagents | Explore, Plan, general-purpose for specialized work |
+| Task tracking | TaskCreate/Update/List for progress visibility (optional) |
+| Plan mode | EnterPlanMode/ExitPlanMode for structured planning |
+| Native tools | Read, Grep, Glob instead of bash equivalents |
+
 ## Repository Structure
 
 ```
@@ -219,12 +227,11 @@ The `install.sh` script automatically backs up existing configs to:
 User: /plan
 
 Claude Code:
-1. Reads commands/plan.md
-2. Sees Prerequisites: rules/universal.md, rules/planning.md
-3. Reads those rules
-4. Executes planning workflow
-5. Calls Codex via `codex exec` for review
-6. Iterates until plan scores 8/10
+1. Rules auto-loaded via CLAUDE.md @-includes
+2. Reads commands/plan.md for workflow steps
+3. Executes planning workflow
+4. Calls Codex via `codex exec` for review
+5. Iterates until plan scores 8/10
 ```
 
 **Claude Code** = Tech Lead (planning, complex reasoning, fixes)

--- a/commands/archive.md
+++ b/commands/archive.md
@@ -2,16 +2,6 @@
 
 Move completed phases from PROJECT.md to PROJECT_ARCHIVE.md.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/planning.md` - PROJECT.md structure
-
-Do not proceed until rules are read and understood.
-
----
-
 ## When to Archive
 
 **Good times:**
@@ -40,9 +30,8 @@ Do not proceed until rules are read and understood.
    - Closed milestone
 
 2. **Read Current PROJECT.md**
-   ```bash
-   cat PROJECT.md
-   ```
+
+   Use the `Read` tool to view PROJECT.md contents.
 
 3. **Determine Sections to Archive**
    

--- a/commands/cherry-pick.md
+++ b/commands/cherry-pick.md
@@ -2,16 +2,6 @@
 
 Cherry-pick commits between branches safely.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/cherry-picking.md` - Cherry-pick-specific rules
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Steps
 
 1. **Identify What to Cherry-Pick**

--- a/commands/explain.md
+++ b/commands/explain.md
@@ -2,16 +2,6 @@
 
 Have Codex explain code sections.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/orchestration.md` - Claude + Codex workflows
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Usage
 ```
 /explain <file>                     # Explain entire file
@@ -23,19 +13,12 @@ Do not proceed until rules are read and understood.
 ## Steps
 
 1. **Determine Scope**
-   ```bash
-   # Entire file
-   cat <file>
-   
-   # Specific function
-   grep -A 100 "function <name>\|def <name>\|<name> =" <file>
-   
-   # Line range
-   sed -n '<start>,<end>p' <file>
-   
-   # Recent changes
-   git diff
-   ```
+
+   Use native tools to gather code:
+   - **Entire file**: Use `Read` tool
+   - **Specific function**: Use `Grep` tool with pattern `function <name>|def <name>`
+   - **Line range**: Use `Read` tool with `offset` and `limit` parameters
+   - **Recent changes**: Use `git diff` via Bash
 
 2. **Codex Explain**
    ```

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -2,17 +2,6 @@
 
 Write code using TDD approach.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/implementation.md` - Implementation-specific rules
-3. `rules/testing.md` - TDD and test rules
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Steps
 
 1. **Pre-Implementation Check**

--- a/commands/investigate.md
+++ b/commands/investigate.md
@@ -2,16 +2,6 @@
 
 Debug issues and find root causes.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/investigation.md` - Investigation-specific rules
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Steps
 
 1. **Document the Problem**

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -2,19 +2,9 @@
 
 Create or refine an implementation plan.
 
-## Prerequisites
-
-**Read these rules first (in order):**
-1. `rules/universal.md` - Core principles
-2. `rules/planning.md` - Planning-specific rules
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Steps
 
-2. **Setup PROJECT.md**
+1. **Setup PROJECT.md**
    - If new: Create from `PROJECT_TEMPLATE.md`
    - If exists: Read and understand current state
 

--- a/commands/refactor-tests.md
+++ b/commands/refactor-tests.md
@@ -2,17 +2,6 @@
 
 Reorganize tests to appropriate testing layers.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/testing.md` - Testing layers and philosophy
-3. `rules/orchestration.md` - Claude + Codex workflows
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Steps
 
 1. **Analyze Current Test Structure**

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -2,16 +2,6 @@
 
 Improve code structure without changing behavior.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/refactor.md` - Refactoring-specific rules
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Steps
 
 1. **Pre-Refactor Checklist**

--- a/commands/review-feedback.md
+++ b/commands/review-feedback.md
@@ -2,17 +2,6 @@
 
 Analyze PR feedback, determine validity, and plan fixes.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/code-review.md` - Review criteria
-3. `rules/orchestration.md` - Claude + Codex workflows
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Usage
 ```
 /review-feedback                    # Prompt for PR link/number

--- a/commands/review-plan.md
+++ b/commands/review-plan.md
@@ -2,17 +2,6 @@
 
 Review implementation plan using Codex, iterating until score ≥ 8/10.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/planning.md` - What makes a good plan
-3. `rules/orchestration.md` - Claude + Codex workflows
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Usage
 ```
 /review-plan                    # Review PROJECT.md (default)
@@ -22,13 +11,8 @@ Do not proceed until rules are read and understood.
 ## Steps
 
 1. **Load Plan**
-   ```bash
-   # Default: PROJECT.md
-   cat PROJECT.md
-   
-   # Or specified file
-   cat <path>
-   ```
+
+   Use the `Read` tool to load the plan file (PROJECT.md by default, or specified path).
 
 2. **Codex Review**
    ```

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -5,17 +5,6 @@ Review a third-party PR using scoring framework and Codex verification.
 > **Note**: Claude Code invokes Codex CLI via the **Bash tool**.
 > Run `codex exec ...` commands through Bash, not as a native tool.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/code-review.md` - Review criteria and scoring
-3. `rules/orchestration.md` - Claude + Codex workflows
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Usage
 ```
 /review-pr <pr-number-or-url>

--- a/commands/review.md
+++ b/commands/review.md
@@ -5,17 +5,6 @@ Code review using Codex, iterating until score ≥ 8/10.
 > **Note**: Claude Code invokes Codex CLI via the **Bash tool**.
 > Run `codex exec ...` commands through Bash, not as a native tool.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/code-review.md` - Review criteria and scoring
-3. `rules/orchestration.md` - Claude + Codex workflows
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Usage
 ```
 /review                     # Review uncommitted changes (default)

--- a/commands/start.md
+++ b/commands/start.md
@@ -2,16 +2,6 @@
 
 Start a new work session. Run this first.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles (always)
-2. `rules/orchestration.md` - Claude + Codex workflows
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Steps
 
 1. **Check for PROJECT.md**

--- a/commands/suggest-tests.md
+++ b/commands/suggest-tests.md
@@ -2,17 +2,6 @@
 
 Have Codex suggest test cases for code.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/testing.md` - Testing philosophy (for evaluating suggestions)
-3. `rules/orchestration.md` - Claude + Codex workflows
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Usage
 ```
 /suggest-tests                      # Tests for uncommitted changes
@@ -23,16 +12,11 @@ Do not proceed until rules are read and understood.
 ## Steps
 
 1. **Determine Scope**
-   ```bash
-   # Default: uncommitted changes
-   git diff --name-only
-   
-   # Specific file
-   cat <file>
-   
-   # Specific function
-   grep -A 50 "function <name>\|def <name>\|<name> =" <file>
-   ```
+
+   Use native tools to gather code:
+   - **Uncommitted changes**: Use `git diff --name-only` via Bash
+   - **Specific file**: Use `Read` tool
+   - **Specific function**: Use `Grep` tool with pattern and context
 
 2. **Codex Generate Tests**
    ```

--- a/commands/test.md
+++ b/commands/test.md
@@ -2,16 +2,6 @@
 
 Write and organize tests.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/testing.md` - Testing-specific rules
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Steps
 
 1. **Determine Test Type**

--- a/commands/update-project-file.md
+++ b/commands/update-project-file.md
@@ -2,22 +2,11 @@
 
 Sync PROJECT.md with current progress.
 
-## Prerequisites
-
-**Read these rules first:**
-1. `rules/universal.md` - Core principles
-2. `rules/planning.md` - PROJECT.md structure
-
-Do not proceed until rules are read and understood.
-
----
-
 ## Steps
 
 1. **Read Current PROJECT.md**
-   ```bash
-   cat PROJECT.md
-   ```
+
+   Use the `Read` tool to view PROJECT.md contents.
 
 2. **Check Recent Activity**
    ```bash

--- a/rules/investigation.md
+++ b/rules/investigation.md
@@ -10,6 +10,9 @@
 
 ## Investigation Process
 
+> **Tip**: For codebase exploration, consider using the Task tool with Explore subagent
+> for efficient searching before manual investigation.
+
 ### 1. Document First
 ```markdown
 ## Investigation: [Issue]

--- a/rules/orchestration.md
+++ b/rules/orchestration.md
@@ -24,6 +24,51 @@ codex exec --sandbox read-only "Your prompt here..."
 
 Codex CLI is a separate shell command, NOT a native Claude Code tool.
 
+## Native Claude Code Features (2.1.x)
+
+### Task Tool Subagents
+
+Claude Code can spawn specialized subagents via the Task tool:
+
+| Subagent | Role | Use For |
+|----------|------|---------|
+| **Explore** | Codebase explorer | Finding files, searching code, understanding structure |
+| **Plan** | Architect | Designing implementation approaches |
+| **general-purpose** | Autonomous worker | Multi-step tasks, research, complex searches |
+
+**When to use subagents vs Codex CLI:**
+- **Subagents**: Internal Claude Code work (exploration, planning, research)
+- **Codex CLI**: Independent review/analysis (fresh perspective, multi-AI validation)
+
+### Task Tracking Tools (Optional)
+
+For complex multi-step work, native task tracking is available:
+
+| Tool | Purpose |
+|------|---------|
+| `TaskCreate` | Create a tracked task with description |
+| `TaskUpdate` | Update status (pending → in_progress → completed) |
+| `TaskList` | View all tasks and their status |
+| `TaskGet` | Get full task details |
+
+**When to use**:
+- Complex features with 3+ distinct steps
+- Work that benefits from visible progress tracking
+- Supplement to PROJECT.md, not replacement
+
+### Plan Mode
+
+Claude Code has native plan mode for non-trivial implementation tasks:
+
+- `EnterPlanMode` - Start structured planning with user approval workflow
+- `ExitPlanMode` - Present plan for user approval
+
+**Use plan mode when**:
+- Multiple valid approaches exist
+- Architectural decisions required
+- Multi-file changes planned
+- User preferences matter
+
 ## Delegation Framework
 
 ### When to Delegate to Codex
@@ -39,12 +84,15 @@ Codex CLI is a separate shell command, NOT a native Claude Code tool.
 
 ### Decision Tree
 ```
+Exploration/understanding codebase?  → Task (Explore subagent)
+Planning/architecture design?        → EnterPlanMode or Task (Plan subagent)
+Multi-step autonomous research?      → Task (general-purpose subagent)
 Planning/investigation/architecture? → Claude Code
-Multi-file or cross-cutting?         → Claude Code  
+Multi-file or cross-cutting?         → Claude Code
 Security-sensitive?                  → Claude Code
 Single-file with clear spec?         → Codex CLI
 Mechanical transformation?           → Codex CLI
-Need fresh perspective?              → Codex CLI
+Need fresh perspective/validation?   → Codex CLI
 ```
 
 ## Task Specification

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -50,11 +50,17 @@ Version control, file analysis, code changes, testing, investigation
 
 ## Plan Mode
 
-When in plan mode, Claude should:
+### Options
+- **Manual planning**: Use PROJECT.md workflow (documented below)
+- **Native plan mode**: Use `EnterPlanMode` for structured planning with user approval workflow
+
+### When in Plan Mode
+Claude should:
 - **Read and update PROJECT.md** - This is expected and encouraged
 - **Explore codebase** - Understand existing patterns and constraints
 - **Document findings** - Add to PROJECT.md as you learn
 - **Iterate on the plan** - Refine based on discoveries
+- **Exit with `ExitPlanMode`** - Present plan for user approval
 
 Plan mode is for active planning work, not just reading.
 


### PR DESCRIPTION
## Summary

- Remove redundant prerequisites from all 16 command files (rules now auto-loaded via CLAUDE.md @-includes)
- Add Native Claude Code Features (2.1.x) section to orchestration.md documenting Task subagents, Task tracking tools, and Plan mode
- Update bash examples to recommend native tools (Read, Grep, Glob)
- Add 2.1.x features section to README.md
- Add Explore subagent tip to investigation.md
- Add EnterPlanMode documentation to planning.md

## Test plan

- [x] Run `./install.sh` - verified all 16 commands available
- [x] Verify command files no longer have prerequisites sections
- [x] Verify orchestration.md has new 2.1.x section
- [x] Verify README.md has new features section

🤖 Generated with [Claude Code](https://claude.com/claude-code)