### PR TITLE
Lazy-load rules via commands to reduce context

### DIFF
--- a/commands/cherry-pick.md
+++ b/commands/cherry-pick.md
@@ -1,5 +1,7 @@
 # /cherry-pick - Cherry-Pick Between Branches
 
+@/Users/joeli/opt/code/claude-rules/rules/cherry-picking.md
+
 > **When**: Moving specific changes (bug fixes, isolated features) across branches.
 > **Produces**: Clean cherry-pick -x with decisions documented in PROJECT.md.
 

--- a/commands/generate-tests.md
+++ b/commands/generate-tests.md
@@ -1,5 +1,7 @@
 # /generate-tests - Write Automated Test Code
 
+@/Users/joeli/opt/code/claude-rules/rules/testing.md
+
 > **When**: Creating or restructuring automated test files (unit, integration, e2e).
 > **Produces**: Test code following project conventions with proper fixtures and mocking.
 

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -1,5 +1,7 @@
 # /implement - Implementation Workflow
 
+@/Users/joeli/opt/code/claude-rules/rules/implementation.md
+
 > **When**: Ready to implement a planned change.
 > **Produces**: Committed, tested code following project conventions.
 

--- a/commands/investigate.md
+++ b/commands/investigate.md
@@ -1,5 +1,7 @@
 # /investigate - Investigation & Root Cause
 
+@/Users/joeli/opt/code/claude-rules/rules/investigation.md
+
 > **When**: Something is broken and you need to find why.
 > **Produces**: Root cause analysis documented in PROJECT.md.
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,5 +1,8 @@
 # /plan - Planning Workflow
 
+@/Users/joeli/opt/code/claude-rules/rules/planning.md
+@/Users/joeli/opt/code/claude-rules/PROJECT_TEMPLATE.md
+
 > **When**: Facing a non-trivial task that needs a plan before coding.
 > **Produces**: Documented implementation plan in PROJECT.md.
 

--- a/commands/qa-discover.md
+++ b/commands/qa-discover.md
@@ -1,5 +1,7 @@
 # /qa-discover - Discover Bugs via Code Analysis
 
+@/Users/joeli/opt/code/claude-rules/rules/testing.md
+
 > **When**: Exploring a feature area to find potential bugs, edge cases,
 >   missing validations, and asymmetries before or instead of manual testing.
 > **Produces**: Categorized use case matrix in PROJECT.md with severity/confidence ratings.

--- a/commands/qa-test.md
+++ b/commands/qa-test.md
@@ -1,5 +1,7 @@
 # /qa-test - Execute QA Test Plan & File Bugs
 
+@/Users/joeli/opt/code/claude-rules/rules/testing.md
+
 > **When**: You have use cases (from /qa-discover or PROJECT.md) and a running
 >   environment to test against.
 > **Produces**: Bug tickets in issue tracker with repro steps, screenshots/video,
@@ -53,12 +55,54 @@
 ## Evidence Organization
 ```
 qa-evidence/
+  videos/
+    sc-NNNNN-description.webm
   UC-143/
     screenshot.png
     console-log.txt
-  UC-145/
-    screenshot.png
 ```
+
+### Video Recording via Playwright
+Record video evidence by creating a new browser context with `recordVideo` enabled.
+Copy cookies from the main session to avoid re-login. Close the context to finalize the video.
+Name videos descriptively: `sc-NNNNN-short-description.webm`
+
+## QA Verification Comment Format
+
+When posting QA results on a story, use **one clean comment** per story:
+
+```markdown
+## QA Verification — PASS ✅
+
+**Tested on**: <staging-url> (staging)
+**Date**: <YYYY-MM-DD>
+**Tester**: Playwright automation (<email>)
+
+### Repro steps followed:
+1. <exact step matching what the video shows>
+2. <step 2>
+...
+
+### Result:
+**Bug appears fixed.** <description of observed behavior>
+
+### Evidence:
+[filename.webm](<shortcut-media-url-from-uploaded-file>)
+```
+
+### Rules:
+- **Repro steps MUST match what the video actually shows** — never describe steps that aren't visible in the recording
+- One comment, one video — no multi-comment update chains
+- Embed the video link in Evidence using the Shortcut media URL from the upload
+- For FAIL: replace header with `## QA Verification — FAIL ❌` and describe what went wrong
+
+## Story State Transitions
+
+When a bug passes QA:
+1. Upload video evidence to the story
+2. Post QA verification comment (format above)
+3. Set custom fields: **QA Assigned** and **Card Status** = "Passed QA"
+4. Move story to **Validate/QA** workflow state
 
 ## Bug Filing Checklist
 - [ ] Title is specific (not "filter broken" but "filter fields hidden until clicked when editing existing alert")
@@ -73,3 +117,6 @@ qa-evidence/
 - Group related use cases to minimize navigation
 - If browser automation unavailable, document manual repro steps
 - For intermittent failures, note frequency and any patterns
+- **Verify element selectors before recording** — use the main browser session to snapshot the DOM and identify correct selectors, then record with the verified selectors
+- **Icons in antd are `span[role="img"]`** not `<img>` — accessibility snapshots may show `img` but the actual DOM uses antd span icons
+- **Avoid generic selectors like `.last()`** — they grab page elements instead of component-scoped elements

--- a/commands/refactor-tests.md
+++ b/commands/refactor-tests.md
@@ -1,5 +1,8 @@
 # /refactor-tests - Move Tests to Correct Layers
 
+@/Users/joeli/opt/code/claude-rules/rules/testing.md
+@/Users/joeli/opt/code/claude-rules/rules/refactor.md
+
 > **When**: Tests are in the wrong layer (e.g., integration tests that should be unit).
 > **Produces**: Reorganized test files at correct testing layers.
 

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -1,5 +1,7 @@
 # /refactor - Refactoring Workflow
 
+@/Users/joeli/opt/code/claude-rules/rules/refactor.md
+
 > **When**: Code needs restructuring without behavior changes.
 > **Produces**: Refactored code with all tests still passing.
 

--- a/commands/review-feedback.md
+++ b/commands/review-feedback.md
@@ -1,5 +1,7 @@
 # /review-feedback - Process PR Feedback
 
+@/Users/joeli/opt/code/claude-rules/rules/code-review.md
+
 > **When**: A PR has review comments that need to be addressed.
 > **Produces**: Addressed feedback with commits.
 

--- a/commands/review-issue.md
+++ b/commands/review-issue.md
@@ -1,5 +1,8 @@
 # /review-issue - Verify Bug Across Branches
 
+@/Users/joeli/opt/code/claude-rules/rules/investigation.md
+@/Users/joeli/opt/code/claude-rules/rules/cherry-picking.md
+
 > **When**: You have a bug report and need to know if it exists in your
 >   current branch, master, or both — and find the fixing commit if applicable.
 > **Produces**: Branch status matrix. If fixed elsewhere, the fixing commit

--- a/commands/review-plan.md
+++ b/commands/review-plan.md
@@ -1,5 +1,7 @@
 # /review-plan - Plan Review (Iterate to 8/10)
 
+@/Users/joeli/opt/code/claude-rules/rules/planning.md
+
 > **When**: A plan exists and needs quality review before implementing.
 > **Produces**: Iterated plan scoring 8/10+.
 

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -1,5 +1,7 @@
 # /review-pr - Review GitHub Pull Request
 
+@/Users/joeli/opt/code/claude-rules/rules/code-review.md
+
 > **When**: Asked to review a GitHub PR.
 > **Produces**: Scored review with actionable feedback.
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,5 +1,7 @@
 # /review - Code Review (Iterate to 8/10)
 
+@/Users/joeli/opt/code/claude-rules/rules/code-review.md
+
 > **When**: Your implementation is ready for quality review.
 > **Produces**: Iterated code scoring 8/10+.
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -1,11 +1,13 @@
 # /start - Initialize Session
 
+@/Users/joeli/opt/code/claude-rules/PROJECT_TEMPLATE.md
+
 > **When**: Beginning any work session.
 > **Produces**: Loaded PROJECT.md context and session entry.
 
 ## Steps
 
-1. **Check for PROJECT.md**
+1. **Check for PROJECT.md in current working directory**
    ```bash
    ls -la PROJECT.md
    ```

--- a/commands/suggest-tests.md
+++ b/commands/suggest-tests.md
@@ -1,5 +1,7 @@
 # /suggest-tests - Generate Test Cases (Codex)
 
+@/Users/joeli/opt/code/claude-rules/rules/testing.md
+
 > **When**: Analyzing code to identify what needs testing.
 > **Produces**: Prioritized test case list with coverage notes.
 

--- a/commands/update-project-file.md
+++ b/commands/update-project-file.md
@@ -1,5 +1,7 @@
 # /update-project-file - Update PROJECT.md
 
+@/Users/joeli/opt/code/claude-rules/rules/planning.md
+
 > **When**: PROJECT.md needs refreshing with current state.
 > **Produces**: Updated PROJECT.md sections.
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -1,11 +1,2 @@
 @/Users/joeli/opt/code/claude-rules/rules/universal.md
-@/Users/joeli/opt/code/claude-rules/rules/cherry-picking.md
-@/Users/joeli/opt/code/claude-rules/rules/code-review.md
-@/Users/joeli/opt/code/claude-rules/rules/implementation.md
-@/Users/joeli/opt/code/claude-rules/rules/investigation.md
-@/Users/joeli/opt/code/claude-rules/rules/orchestration.md
-@/Users/joeli/opt/code/claude-rules/rules/planning.md
-@/Users/joeli/opt/code/claude-rules/rules/refactor.md
-@/Users/joeli/opt/code/claude-rules/rules/testing.md
-@/Users/joeli/opt/code/claude-rules/rules/troubleshooting.md
-@/Users/joeli/opt/code/claude-rules/PROJECT_TEMPLATE.md
+@/Users/joeli/opt/code/claude-rules/rules/resource-management.md

--- a/rules/resource-management.md
+++ b/rules/resource-management.md
@@ -1,0 +1,35 @@
+# Resource Management Principles
+
+## Golden Rules
+- [ ] **Check resources before consuming them** — Docker, test workers, builds
+- [ ] **One stack at a time** — shut down before starting another
+- [ ] **Scale workers to available resources** — not to CPU count
+
+## Docker Container Management
+
+**Before starting any Docker containers:**
+1. Run `docker ps` to check running containers
+2. If **2 or fewer** containers are running → proceed
+3. If **more than 2** → show the running containers to the user and ask whether to stop any before starting new ones, or start anyway
+
+**Rationale**: Each Superset stack (app + DB + extras) uses 4-6 GB RAM. Multiple stacks saturate the Docker VM and crash the host.
+
+## Test Worker Management
+
+**Before running test suites (Jest, pytest, Playwright):**
+1. Check system resources: `sysctl -n hw.ncpu` and available memory
+2. Check what else is running: `docker ps -q | wc -l` for Docker load
+3. Calculate appropriate `maxWorkers`:
+
+| Condition | maxWorkers | Flag |
+|-----------|-----------|------|
+| Docker stack running | 2 | `--maxWorkers=2` |
+| No Docker, light usage | 4 | `--maxWorkers=4` |
+| Single test file | 1-2 | `--maxWorkers=2` |
+| Full suite, nothing else running | 50% of CPUs | `--maxWorkers=50%` |
+
+**Always pass `--maxWorkers` to Jest** — the default (CPUs - 1) spawns too many workers and causes OOM crashes.
+
+**For pytest**: Use `-n` with pytest-xdist following the same worker guidelines, or omit for sequential runs.
+
+**For Playwright**: Workers are configured in `playwright.config.ts` — check `workers` setting before running.

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -47,6 +47,7 @@
 | `implementation.md` | Code development, TDD, patterns |
 | `testing.md` | Test strategy, mocking, over-mocking signals |
 | `troubleshooting.md` | Emergency recovery |
+| `resource-management.md` | Docker limits, test worker scaling |
 | `cherry-picking.md` | Cross-branch work |
 | `code-review.md` | Review guidelines, scoring |
 | `refactor.md` | Restructuring without behavior changes |


### PR DESCRIPTION
## Summary
- Move domain-specific rule `@` imports from `config/CLAUDE.md` (loaded every session) into individual command files (loaded on-demand only when the command is invoked)
- Fix command descriptions by keeping the `# /command - Title` heading as the first line, so the skill list shows readable names instead of raw file paths
- Add `resource-management.md` for Docker container and test worker scaling guidelines

## Test plan
- [ ] Verify `/help` or skill list shows proper command descriptions (not `@` file paths)
- [ ] Invoke a command (e.g. `/plan`) and confirm the rule file context is still loaded
- [ ] Confirm `config/CLAUDE.md` only loads `universal.md` and `resource-management.md` at session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)