### PR TITLE
feat: autonomous workflow chaining + insights friction fixes

### DIFF
--- a/commands/address-feedback.md
+++ b/commands/address-feedback.md
@@ -5,6 +5,9 @@
 > **When**: A PR has review comments that need to be addressed.
 > **Produces**: Fixes committed, responses drafted or posted.
 
+## Golden Rule
+Triage is step 1, not the goal. The point is to fix things and respond, not to produce a triage table.
+
 ## Usage
 ```
 /address-feedback <pr-url>
@@ -19,24 +22,30 @@
    gh api repos/<owner>/<repo>/pulls/<number>/comments
    ```
 
-2. **Triage Each Comment**
+2. **Investigate Each Comment**
+
+   For each review comment, before triaging:
+   - Read the actual code referenced by the comment
+   - Verify the reviewer's claim is correct (don't assume)
+   - Check if the issue is already handled elsewhere (guard clause upstream, try/catch wrapper, etc.)
+   - Check git blame to understand why the code is the way it is
+
+   This is evidence-based triage, not guess-based.
+
+3. **Triage with Evidence**
 
    For each feedback item:
    ```markdown
-   | # | Reviewer | Comment | Verdict | Reason |
-   |---|----------|---------|---------|--------|
-   | 1 | @alice | Missing null check | Fix | Valid — unhandled edge case |
-   | 2 | @bob | Use a factory pattern | Skip | Style preference, not project convention |
-   | 3 | @alice | What about auth? | Discuss | Ambiguous — need to clarify scope |
+   | # | Reviewer | Comment | Verdict | Evidence |
+   |---|----------|---------|---------|----------|
+   | 1 | @alice | Missing null check | Fix | Confirmed — `getData()` can return null on L42 |
+   | 2 | @bob | Use a factory pattern | Skip | Current approach matches existing pattern in `src/utils/` |
+   | 3 | @alice | What about auth? | Discuss | Auth is handled by middleware (verified in `auth.ts:15`) |
    ```
 
    **Fix**: actual bugs, security issues, missing error handling, project standards
    **Skip**: style preferences, out of scope, misunderstanding, incorrect assessment
    **Discuss**: architectural disagreements, ambiguous requirements, trade-offs
-
-3. **Present Triage to User**
-
-   Show the table. User approves, adjusts, or overrides any verdicts.
 
 4. **Fix Approved Items**
 
@@ -44,6 +53,9 @@
    1. Bugs and security issues
    2. Missing error handling
    3. Standards compliance
+
+   **TDD for behavioral changes**: If a fix adds code, changes a function's behavior, or introduces a new code path → write a test first (RED), then fix (GREEN).
+   **Direct fix for pattern-following**: If the fix follows existing patterns or is cosmetic (naming, formatting, moving code) → fix directly, existing tests cover it.
 
    Commit fixes: `fix: address PR feedback — [summary]`
 
@@ -60,29 +72,62 @@
    > The changes here operate after auth is already validated.
    ```
 
-   **Ask user**: "Post these replies directly to the PR, or just show them for you to post?"
+   **Note**: Comments may be interpreted differently — always let user review drafts before posting.
 
-   If user approves direct posting:
+6. **Present Everything to User**
+
+   Show all at once:
+   - Triage table with evidence
+   - Fixes made (with commit hashes)
+   - Draft responses for skip/discuss items
+   - Ask: "Push commits and post these replies? Or adjust first?"
+
+7. **Push + Post on Approval**
+
+   Only after user approves:
    ```bash
+   git push
+
+   # Reply to specific review comments
+   gh api repos/<owner>/<repo>/pulls/comments/<comment-id>/replies \
+     -f body="<response>"
+
+   # Or post a general PR comment
    gh pr comment <number> --body "<response>"
-   # Or reply to specific review comment
-   gh api repos/<owner>/<repo>/pulls/comments/<comment-id>/replies -f body="<response>"
    ```
 
-6. **Summary**
+8. **Summary**
    ```markdown
    ## Feedback Addressed
 
    **PR**: #[number]
-   - **Fixed**: X items (committed)
-   - **Skipped**: X items (responses drafted/posted)
-   - **Discussed**: X items (responses drafted/posted)
+   - **Fixed**: X items (committed + pushed)
+   - **Skipped**: X items (responses posted)
+   - **Discussed**: X items (responses posted)
 
    ### Next Steps
    - Request re-review if fixes were made
    ```
 
+## GitHub API Reference
+
+```bash
+# List review comments (code-level)
+gh api repos/<owner>/<repo>/pulls/<number>/comments
+
+# List issue comments (general PR comments)
+gh api repos/<owner>/<repo>/issues/<number>/comments
+
+# Reply to a specific review comment
+gh api repos/<owner>/<repo>/pulls/comments/<comment-id>/replies \
+  -f body="<response>"
+
+# Post a general PR comment
+gh pr comment <number> --body "<response>"
+```
+
 ## Notes
-- Always present triage to user before acting
+- Always investigate before triaging — read the actual code
+- Present triage + fixes + draft responses to user before pushing/posting
+- TDD for behavioral changes, direct fix for cosmetic/pattern-following changes
 - Ask before posting any replies to the PR
-- Fix items get committed, skip/discuss items get responses

--- a/commands/analyze-tests.md
+++ b/commands/analyze-tests.md
@@ -1,4 +1,4 @@
-# /audit-tests - Audit Test Coverage and Discover Bugs
+# /analyze-tests - Analyze Test Coverage and Discover Bugs
 
 @/Users/joeli/opt/code/claude-rules/rules/testing.md
 

--- a/commands/cherry-pick.md
+++ b/commands/cherry-pick.md
@@ -53,16 +53,27 @@
 
 4. **Handle Conflicts**
 
-   If conflicts occur, determine the cause:
+   If conflicts occur, first verify cherry-pick state:
+   ```bash
+   # Verify cherry-pick is in progress
+   test -f .git/CHERRY_PICK_HEAD && echo "Cherry-pick active" || echo "WARNING: No active cherry-pick"
+   ```
+
+   **If `.git/CHERRY_PICK_HEAD` does not exist**: the cherry-pick state was lost. Do NOT run `--continue`. Instead, re-run the cherry-pick from step 3.
+
+   Determine the cause of conflicts:
 
    **Option A: Resolvable conflicts**
-   Spawn Task subagents in parallel to resolve each conflicting file:
-   - Pass the file's conflict diff, target branch context, and source intent
-   - Each agent resolves its file and explains the resolution
+   Spawn parallel Task subagents — one per conflicting file:
+   - Pass each agent: the file's conflict diff, target branch context, source intent
+   - Each agent resolves its file independently and explains the resolution
+   - Agents run in parallel for speed
 
-   After resolving:
+   After all agents complete, collect resolutions and apply:
    ```bash
    git add <resolved-files>
+   # Verify cherry-pick state is still active
+   test -f .git/CHERRY_PICK_HEAD
    git cherry-pick --continue
    ```
 
@@ -111,8 +122,17 @@
    - [Any commits cherry-picked first to enable this one]
    ```
 
+## Chained Cherry-Pick Safety
+
+When cherry-picking multiple commits in sequence:
+- Verify each cherry-pick completes before starting the next
+- If one fails mid-chain, do NOT continue with subsequent picks
+- Clean up the failed state (`git cherry-pick --abort`) before deciding next steps
+- Document which picks succeeded and which didn't
+
 ## Notes
 - Always use `cherry-pick -x` to preserve source reference
+- Always verify `.git/CHERRY_PICK_HEAD` before `--continue`
 - Always use `cherry-pick --continue` after resolving conflicts (preserves author + metadata)
 - Prefer functional over structural changes
 - When in doubt, reject

--- a/commands/create-plan.md
+++ b/commands/create-plan.md
@@ -101,8 +101,26 @@
 - Prefer vertical slices (one feature end-to-end) over horizontal layers (all models, then all APIs, then all UI)
 - Each phase's PR should be small enough to review in one sitting
 
+## Auto-Chain
+
+After the plan is written to PROJECT.md, automatically continue:
+
+1. **Invoke `/review-plan`** — run multi-round expert review
+   - Iterate until ALL reviewers score >= 8/10
+   - No round limit — keep iterating until threshold is met
+   - Each round: apply feedback, re-run reviewers
+
+2. **Invoke `/finalize-plan`** — fresh-eyes final review
+   - Cold-read Go/No-Go assessment
+   - **Enhanced output**: Include an iteration summary showing:
+     - Starting score → final score
+     - What changed in each review round and why
+     - Key decisions made during iteration
+
+3. **STOP** — present the finalized plan to the user
+   - User reviews and decides whether to proceed to `/implement`
+
 ## Notes
 - Document multiple options with trade-offs
 - Plan should be actionable — ready to implement
-- Do NOT auto-trigger review — let user decide when to review
-- Full flow: `/create-plan` → `/review-plan` → `/finalize-plan` → `/implement`
+- Full flow: `/create-plan` → auto: `/review-plan` → `/finalize-plan` → **GATE** → `/implement`

--- a/commands/diagnose-ci.md
+++ b/commands/diagnose-ci.md
@@ -1,0 +1,84 @@
+# /diagnose-ci - Diagnose CI Failures
+
+@/Users/joeli/opt/code/claude-rules/rules/implementation.md
+
+> **When**: A CI build has failed and you need to diagnose and fix it.
+> **Produces**: Diagnosis of failures, auto-fixes for known patterns, recommendations for novel failures.
+
+## Usage
+```
+/diagnose-ci <run-url>          # Diagnose a specific CI run
+/diagnose-ci <pr-number>        # Diagnose latest CI run for a PR
+/diagnose-ci                    # Diagnose latest CI run for current branch
+```
+
+## Steps
+
+1. **Gather CI Logs**
+   ```bash
+   # Get failed run
+   gh run list --branch <branch> --status failure --limit 1
+   gh run view <run-id> --log-failed
+
+   # Or from PR
+   gh pr checks <number>
+   gh run view <run-id> --log-failed
+   ```
+
+2. **Classify Failures**
+
+   Read `skills/diagnose-ci/SKILL.md` for the known failure pattern table.
+
+   Spawn parallel Task subagents — one per failure category detected:
+   - **Build failures**: type errors, missing imports, syntax errors
+   - **Test failures**: assertion failures, timeouts, flaky tests
+   - **Lint/format failures**: ESLint, prettier, ruff
+   - **Environment failures**: missing deps, Docker issues, CI config
+
+   Each agent:
+   - Matches the failure against known patterns from the skill
+   - Reads the relevant source files
+   - Assigns a confidence level: **HIGH** / **MEDIUM** / **LOW**
+
+3. **Act Based on Confidence**
+
+   **HIGH confidence** (matches a known pattern exactly):
+   - Fix it directly
+   - Run tests locally to verify the fix
+   - Commit: `fix: resolve CI failure — [description]`
+
+   **MEDIUM confidence** (likely matches a pattern but has ambiguity):
+   - Present diagnosis to user with proposed fix
+   - Wait for approval before applying
+
+   **LOW confidence** (novel failure, unclear cause):
+   - Present full diagnosis with log excerpts
+   - Suggest investigation steps
+   - Do NOT auto-fix
+
+4. **Summary**
+   ```markdown
+   ## CI Diagnosis
+
+   ### Run: [run-id / url]
+   ### Branch: [branch]
+
+   ### Auto-Fixed (HIGH confidence)
+   - [What was fixed and why]
+
+   ### Proposed Fixes (MEDIUM confidence)
+   - [Diagnosis + proposed fix, awaiting approval]
+
+   ### Needs Investigation (LOW confidence)
+   - [Diagnosis + suggested next steps]
+
+   ### Verification
+   - [ ] Local tests pass after fixes
+   - [ ] Build succeeds locally
+   ```
+
+## Notes
+- Always read the actual failing log output — don't guess from job names alone
+- Known patterns are in `skills/diagnose-ci/SKILL.md` — update that file when you encounter new recurring patterns
+- Only auto-fix HIGH confidence matches; everything else goes through the user
+- Run local verification before committing any fix

--- a/commands/finalize-plan.md
+++ b/commands/finalize-plan.md
@@ -28,12 +28,29 @@
 
 3. **Present Findings**
 
-   Show the expert's full report to the user:
+   Show the expert's full report to the user, plus the iteration history:
+
+   ```markdown
+   ## Plan Finalization
+
+   ### Iteration History
+
+   | Round | Score | Key Changes |
+   |-------|-------|-------------|
+   | 1 | X/10 | [What was changed and why] |
+   | 2 | X/10 | [What was changed and why] |
+   | ... | ... | ... |
+   | Final | X/10 | [Final state summary] |
+
+   ### Fresh-Eyes Assessment
    - Summary
    - Score (1-10)
    - Blocking Issues
    - Risks
-   - Go/No-Go Recommendation
+
+   ### Go/No-Go
+   [Recommendation with reasoning]
+   ```
 
 4. **Decision**
 
@@ -44,4 +61,5 @@
 - The fresh expert has NO context from prior reviews — this is intentional
 - Cold read catches groupthink and iteration bias
 - Single pass, no iteration loop — this is a final gate
-- Full flow: `/create-plan` → `/review-plan` → `/finalize-plan` → `/implement`
+- Iteration history provides context on how the plan evolved
+- Full flow: `/create-plan` → auto: `/review-plan` → `/finalize-plan` → **GATE** → `/implement`

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -7,73 +7,92 @@
 
 ## Steps
 
-1. **Pre-Implementation Check**
-   - [ ] Plan exists in PROJECT.md? (run `/create-plan` first if not)
-   - [ ] Codebase understood?
-   - [ ] Existing patterns studied?
-   - [ ] Dependencies verified?
+1. **Pre-Implementation Checks (Parallel Agents)**
 
-2. **Study Existing Patterns**
-   ```bash
-   # Find similar implementations
-   grep -r "similar-feature" .
-   find . -name "*related*" -type f
-   
-   # Check conventions
-   head -30 <similar-file>
-   ```
+   Read PROJECT.md for the approved plan, then spawn parallel Task subagents:
 
-3. **TDD Cycle**
-   
-   **RED** - Write failing test first
+   **Agent 1: Environment Verification**
+   - Verify correct branch and clean working tree
+   - Check `node_modules` / virtualenv / dependencies are installed
+   - If missing: install them (`npm install`, `pip install -r requirements.txt`, etc.)
+   - Verify build outputs are fresh (no stale `.d.ts`, compiled JS, etc.)
+   - If stale: rebuild affected packages
+
+   **Agent 2: Local Environment Setup** (if PROJECT.md or project config specifies how)
+   - Check if a local stack is needed for testing (Docker, dev server, etc.)
+   - If instructions exist: spin it up (respecting resource-management rules — check `docker ps` first)
+   - If no instructions: skip, note that testing will be unit/integration only
+
+   **Agent 3: Dependency Audit**
+   - Verify imports/packages referenced in the plan actually exist in the project
+   - Check for version conflicts or missing peer dependencies
+   - Flag anything that needs manual resolution
+
+   **These agents run in the background** — do NOT wait for them before starting TDD.
+   - If an agent encounters issues, it should try to resolve them autonomously (install deps, rebuild, etc.)
+   - Only surface to the user at the end (in the summary) or if resolution fails and blocks testing
+   - Implementation proceeds in parallel with environment setup
+
+2. **Write Tests (RED)**
+   - Generate tests based on the plan's testing strategy
+   - Run tests — they should FAIL (confirms they test the right thing)
+
+3. **Review Tests**
+
+   Invoke `/review-code` on the test files.
+   (`/review-code` handles its own loop internally — review, fix, re-review until clean.)
+
+   Commit passing test structure: `test: add tests for [feature]`
+
+4. **Write Implementation (GREEN)**
+   - Implement the minimum code to make tests pass
+   - Follow existing patterns, keep changes focused
+
+5. **Review Implementation**
+
+   Invoke `/review-code` on the implementation files.
+   (`/review-code` handles its own loop internally.)
+
+6. **Refactor (if needed)**
+   - Clean up only if there are clear improvements
+   - Run tests after refactoring
+
+7. **Commit**
+   - Commit working implementation
+   - Pre-flight checks: build, type-check, hooks (per implementation.md rules)
+
+8. **Summary**
    ```markdown
-   ### Development Log
-   [Timestamp]: Writing test for [feature]
-   - Test: [what it tests]
-   - Expected: [behavior]
-   ```
-   
-   **GREEN** - Minimal code to pass
-   ```markdown
-   [Timestamp]: Implementing to pass test
-   - Approach: [what you're doing]
-   ```
-   
-   **REFACTOR** - Improve while green
-   ```markdown
-   [Timestamp]: Refactoring
-   - Tests still passing: Yes
-   - Changes: [what improved]
+   ## Implementation Complete
+
+   ### Tests Written
+   - [List of test files and what they cover]
+
+   ### Code Changes
+   - [List of implementation files and what changed]
+
+   ### Review-Code Rounds
+   - Tests: X rounds, Y issues fixed
+   - Implementation: X rounds, Y issues fixed
+
+   ### Remaining Nitpicks (not fixed)
+   - [Any items noted but not addressed]
+
+   ### Ambiguities Surfaced (needs user input)
+   - [Any items where review-code couldn't decide]
    ```
 
-4. **Implementation Standards**
-   - Functions ≤20 lines (guideline)
-   - Files ≤300 lines
-   - Nesting ≤2 levels
-   - Match existing patterns
-   - YAGNI - only what's needed now
+## Review-Code Loop Termination Rules
+- **Stop** when only `[nitpick]` items remain
+- **Stop** when there's ambiguity that needs user input (present the question)
+- **Continue** as long as `[major]` or `[minor]` items exist
 
-5. **Safe Commits**
-   ```bash
-   # Review changes
-   git diff
-   git status
-   
-   # Check for debug code
-   grep -r "TODO\|FIXME\|console\|debug\|print" .
-   
-   # Stage individually (NEVER git add -A)
-   git add <specific-file>
-   
-   # Commit
-   git commit -m "feat: [description]"
-   ```
-
-6. **Handoff**
-   ```
-   Implementation complete.
-   Run /review to validate, then create a PR.
-   ```
+## Implementation Standards
+- Functions ≤20 lines (guideline)
+- Files ≤300 lines
+- Nesting ≤2 levels
+- Match existing patterns
+- YAGNI - only what's needed now
 
 ## Commit Message Format
 ```
@@ -90,4 +109,3 @@ Types: feat, fix, docs, style, refactor, test, chore
 - Working solution first, then optimize
 - Commit working states before refactoring
 - Test as you go, not at the end
-- Do NOT auto-trigger review — let user decide when to run `/review`

--- a/commands/investigate.md
+++ b/commands/investigate.md
@@ -92,11 +92,11 @@
 
    Write the validated RCA to PROJECT.md.
 
-9. **Handoff**
-   ```
-   Root cause documented in PROJECT.md.
-   Run /create-plan to plan the fix.
-   ```
+9. **Auto-Chain: Create Plan**
+
+   After validated RCA is documented in PROJECT.md, automatically invoke `/create-plan`:
+   - Pass the RCA context (root cause, evidence, introducing commit)
+   - `/create-plan` will use this as the foundation for the fix plan
 
 ## Notes
 - Always use git history first

--- a/commands/review-code.md
+++ b/commands/review-code.md
@@ -1,0 +1,87 @@
+# /review-code - Auto-Fix Local Code Review
+
+@/Users/joeli/opt/code/claude-rules/rules/code-review.md
+
+> **When**: You have local uncommitted changes and want a quality pass before committing.
+> **Produces**: Fixed code with only nitpicks remaining, plus a summary of changes made.
+
+## Usage
+```
+/review-code                    # Review all uncommitted changes
+/review-code src/api/           # Review changes in specific path
+/review-code --files a.ts b.ts  # Review specific files
+```
+
+## Steps
+
+1. **Gather Changes**
+   ```bash
+   git diff --name-only          # Unstaged changes
+   git diff --cached --name-only # Staged changes
+   ```
+   If a path or files are specified, filter to those. Read each changed file.
+
+2. **Review**
+
+   For each changed file, evaluate against code-review.md principles:
+
+   **Code quality**:
+   - Logic errors, off-by-ones, null safety
+   - Missing error handling at system boundaries
+   - DRY violations, unnecessary complexity
+   - Pattern violations (doesn't match existing codebase conventions)
+   - Naming clarity
+
+   **Test gap detection** (scoped to changed code only):
+   - Does the changed code introduce new behavior that lacks tests?
+   - Does it modify existing behavior without updating tests?
+   - If yes → that's a `[major]` finding. Write the missing test as part of the fix.
+   - (Broader coverage analysis is `/analyze-tests`' job, not this command's.)
+
+   Tag each finding: `[major]`, `[minor]`, or `[nitpick]` per code-review.md severity tags.
+
+3. **Fix**
+
+   Fix all `[major]` and `[minor]` issues directly:
+   - For code quality issues: edit the files
+   - For test gaps: write the missing test (RED → verify it fails → GREEN → verify it passes)
+   - Run existing tests after each fix to verify no regressions
+   - If a fix causes a test regression, revert it and flag for user input
+
+4. **Re-Review (Loop)**
+
+   After fixing, review the changed files again (including the fixes themselves).
+   Fixes can introduce new issues — catch them.
+
+   **Continue looping** as long as `[major]` or `[minor]` items exist.
+
+   **Stop when**:
+   - Only `[nitpick]` items remain
+   - Ambiguity that needs user input (present the question)
+   - Same issue persists across 2 consecutive rounds (flag it — may need user decision)
+
+5. **Summary**
+   ```markdown
+   ## Review-Code Complete
+
+   ### Rounds: [N]
+
+   ### Fixed
+   - [List of issues fixed, grouped by file]
+
+   ### Tests Added
+   - [Any tests written to cover gaps]
+
+   ### Remaining Nitpicks
+   - [Items noted but not fixed — optional improvements]
+
+   ### Needs User Input
+   - [Any ambiguities or trade-offs that couldn't be resolved automatically]
+   ```
+
+## Notes
+- This command is used standalone (`/review-code`) and also invoked by `/implement` during TDD
+- Does NOT shadow the built-in `/review` command
+- Only reviews changed code — not the entire codebase
+- Test gap detection is scoped to changed code; use `/analyze-tests` for broader coverage analysis
+- Reverts fixes that cause test regressions rather than shipping broken code

--- a/commands/review-plan.md
+++ b/commands/review-plan.md
@@ -77,24 +77,20 @@
    - [Conflict description + resolution]
    ```
 
-5. **User Decision**
+5. **Iteration Loop**
 
-   Present options:
-   - **Iterate**: Claude improves the plan (consensus first, then High, then Medium), updates PROJECT.md, re-runs review
-   - **Finalize**: Plan is good enough → suggest `/finalize-plan`
-   - **Accept**: Skip finalization, go straight to `/implement`
-   - **Manual**: User will address feedback themselves
-
-6. **Iteration Loop** (if user chooses "Iterate")
+   Automatically iterate — no user prompt between rounds:
 
    1. Claude improves plan content directly in PROJECT.md (not as comments)
       - Address consensus issues first
       - Then High priority issues
-      - Then Medium if time permits
+      - Then Medium priority issues
    2. Re-run from step 2 with improved plan
-   3. Max **3 rounds**, then suggest `/finalize-plan`
+   3. **Continue iterating until ALL reviewers score >= 8/10. No fixed round limit.**
 
-7. **Final Report**
+   If iteration stalls (same issues persist across 2 consecutive rounds), stop and surface the blocking issues to the user.
+
+6. **Final Report**
    ```markdown
    ## Review Complete
 
@@ -103,10 +99,10 @@
    |-------|-----------|------------------|
    | 1 | 5.5 | Missing risk assessment |
    | 2 | 7.8 | Added testing strategy |
+   | 3 | 8.4 | Addressed phase decomposition |
 
-   ### Next Steps
-   - Run `/finalize-plan` for fresh-eyes final check
-   - Or `/implement` to begin implementation
+   ### Status
+   All reviewers >= 8/10. Plan ready for finalization.
    ```
 
 ## Notes
@@ -114,4 +110,5 @@
 - All reviewers run in parallel for speed
 - Consensus issues (2+ reviewers) get highest priority
 - Claude improves plan content directly — never writes review comments into PROJECT.md
-- Max 3 iteration rounds, then suggest finalization
+- No fixed round limit — iterate until all reviewers score >= 8/10
+- Stall detection: if the same issues persist across 2 consecutive rounds, stop and ask the user

--- a/commands/run-qa.md
+++ b/commands/run-qa.md
@@ -8,7 +8,7 @@
 >   and logs. Updated use case matrix with PASS/FAIL status.
 
 ## Prerequisites
-- Use cases documented in PROJECT.md (run /audit-tests first if needed)
+- Use cases documented in PROJECT.md (run /analyze-tests first if needed)
 - Running environment (local Docker, staging, ephemeral)
 - Browser automation MCP connected (for UI testing)
 - Issue tracker MCP connected (for bug filing)

--- a/commands/start.md
+++ b/commands/start.md
@@ -19,14 +19,22 @@
    - If found: Read completely
    - If not found anywhere: Ask if user wants to create one using `PROJECT_TEMPLATE.md`
 
-2. **Verify Environment**
-   ```bash
-   git status
-   git branch
-   git log --oneline -3
-   ```
+2. **Check for Continuation Checkpoint**
 
-3. **Add Session Entry** (if PROJECT.md exists)
+   If PROJECT.md contains a `## Continuation Checkpoint` section:
+   - Read the checkpoint state (completed commands, next command, scores, context)
+   - Add a session entry noting this is a continuation:
+     ```markdown
+     ### [Timestamp] - Session Resumed
+     - Branch: [current branch]
+     - Resuming from: [checkpoint timestamp]
+     - Next: [next command from checkpoint]
+     ```
+   - **Automatically invoke the next command** from the checkpoint. Do not prompt the user.
+
+3. **Normal Session** (no checkpoint)
+
+   Add session entry:
    ```markdown
    ### [Timestamp] - Session Start
    - Branch: [current branch]
@@ -34,11 +42,10 @@
    - Goal: [ask user]
    ```
 
-4. **Ready Prompt**
    ```
    "Session initialized. What would you like to work on?"
    ```
-   
+
    Suggest relevant commands based on context:
    - New feature → `/create-plan`
    - Debugging/issues → `/investigate`
@@ -49,4 +56,5 @@
 ## Notes
 - This command loads context only
 - Specific workflows load their own rules as needed
+- If a continuation checkpoint exists, resumes automatically — no prompt
 - Always start here for a new session

--- a/rules/cherry-picking.md
+++ b/rules/cherry-picking.md
@@ -4,6 +4,7 @@
 - [ ] **Understand before changing** — analyze full scope
 - [ ] **Always use `cherry-pick -x`** — preserves source commit reference
 - [ ] **Always use `cherry-pick --continue` to commit** — never `git commit` directly after resolving conflicts. `--continue` preserves original author, cherry-pick metadata, and the `(cherry picked from commit ...)` trailer.
+- [ ] **Verify `.git/CHERRY_PICK_HEAD` exists before `--continue`** — if it doesn't, the cherry-pick state was lost (e.g., aborted or already committed). Running `--continue` without it will error or operate on stale state.
 - [ ] **Validate bug exists in target branch** — before cherry-picking a fix, confirm it's present
 - [ ] **Preserve working functionality**
 - [ ] **Adapt rather than force** — work with target architecture

--- a/rules/code-review.md
+++ b/rules/code-review.md
@@ -32,4 +32,5 @@
 ## Related Commands
 - `/review-pr` — Review someone's PR
 - `/review-plan` — Domain expert plan review
+- `/review-code` — Auto-fix local uncommitted changes
 - `/address-feedback` — Address PR review feedback

--- a/rules/implementation.md
+++ b/rules/implementation.md
@@ -9,6 +9,9 @@
 - [ ] **Commit working states** — safe rollback points
 - [ ] **NEVER use `git add -A` or `git add .`** — add only YOUR files
 - [ ] **YAGNI** — build only what's needed now
+- [ ] **Never rewrite git history** unless explicitly asked — no force push, no rebase of shared branches, no amending published commits
+- [ ] **Only amend HEAD** — if asked to amend, verify it's the most recent commit. Never amend older commits without explicit instruction.
+- [ ] **Be factual in PRs** — describe what changed and why, not how great the change is
 
 ## Code Standards
 
@@ -26,8 +29,22 @@
 | Handle errors explicitly | Silent catches |
 | Small, focused commits | Large commits |
 | Add files individually | `git add -A` |
+| `fixup` + `rebase` for old commits | Amend non-HEAD commits |
+| Factual PR descriptions | Hyperbolic language |
+
+## Pre-Flight Checks
+
+**Before every commit**, verify:
+1. **Build passes**: `npm run build`, `tsc --noEmit`, or equivalent
+2. **Type-check passes**: if TypeScript/Flow/mypy is used
+3. **Linting passes**: `npm run lint`, `ruff check`, or equivalent
+4. **Tests pass**: run at minimum the tests related to changed files
+5. **Pre-commit hooks**: let them run — do NOT use `--no-verify`
+
+**In worktrees**: dependencies and build outputs may not exist. Run `npm install` / rebuild before pre-flight checks.
 
 ## Related Commands
 - `/implement` — Write code (TDD workflow)
 - `/plan` — Design implementation approach
 - `/generate-tests` — Write automated test code
+- `/review-code` — Auto-fix local code review

--- a/rules/resource-management.md
+++ b/rules/resource-management.md
@@ -33,3 +33,19 @@
 **For pytest**: Use `-n` with pytest-xdist following the same worker guidelines, or omit for sequential runs.
 
 **For Playwright**: Workers are configured in `playwright.config.ts` — check `workers` setting before running.
+
+## Worktree Management
+
+When working in git worktrees (e.g., `EnterWorktree` or `isolation: "worktree"` agents):
+
+**Shared state pitfalls** — worktrees share `.git` but NOT:
+- `node_modules/` — must install separately in each worktree
+- Build outputs (`dist/`, `.next/`, `__pycache__/`) — must rebuild
+- `.env` files — may need copying from main worktree
+
+**Before running tests or builds in a worktree:**
+1. Check if `node_modules/` exists — if not, run `npm install` (or equivalent)
+2. Check if build outputs are present — if not, rebuild
+3. Copy `.env` / `.env.local` from main worktree if needed
+
+**Cleanup**: Worktrees created by agents are auto-cleaned if no changes were made. If changes exist, the worktree path and branch are returned — merge or delete manually.

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -7,14 +7,16 @@
 - **Incremental progress** — small, verified changes over big risky ones
 - **Document decisions and reasoning** — future maintainers need context
 - **TDD and YAGNI** — test first, build only what's needed now
+- **Update PROJECT.md before completing any workflow** — every command that produces results must write current status, what was done, and remaining items to PROJECT.md before finishing
+- **Checkpoint when context is deep** — at chain boundaries and loop iterations, if context is above ~70%, save state and continue in a fresh conversation (see Context Management below)
 
 ## Workflow Selection
 
 | Situation | Workflow | Command |
 |-----------|----------|---------|
-| Building something new | New Feature | `/create-plan` → `/review-plan` → `/finalize-plan` → `/create-tests` → `/implement` |
-| Something's broken | Bug Fix | `/investigate` → `/create-plan` → `/review-plan` → `/create-tests` → `/implement` |
-| Exploring for bugs | Test Audit | `/audit-tests` |
+| Building something new | New Feature | `/create-plan` → auto: `/review-plan` → `/finalize-plan` → **GATE** → `/implement` |
+| Something's broken | Bug Fix | `/investigate` → auto: `/create-plan` → `/review-plan` → `/finalize-plan` → **GATE** → `/implement` |
+| Exploring for bugs | Test Analysis | `/analyze-tests` |
 | Testing against live env | QA Testing | `/run-qa` |
 | Is this bug fixed somewhere? | Issue Review | `/review-issue` |
 | Reviewing someone's PR | Code Review | `/review-pr` |
@@ -22,6 +24,48 @@
 | Cross-branch work (single) | Cherry-Pick | `/review-issue` → `/cherry-pick` |
 | Cross-branch work (batch) | Cherry-Pick | `/cherry-plan` → `/cherry-pick` each |
 | System in bad state | Recovery | See troubleshooting rules |
+| CI build failed | CI Diagnosis | `/diagnose-ci` |
+| Pre-commit quality pass | Self Review | `/review-code` |
+| PR has review comments | PR Feedback | `/address-feedback` |
+
+**GATE** = user reviews and manually triggers next step.
+
+## Context Management
+
+At every **chain boundary** or **loop iteration**, check context depth:
+
+- **Below ~70%**: Continue automatically. Don't pause.
+- **At or above ~70%**: Save state and continue in a fresh conversation. Don't ask — just do it.
+
+Chain boundaries: `/investigate` → `/create-plan`, `/create-plan` → `/review-plan`, `/review-plan` → `/finalize-plan`, etc.
+Loop iterations: each `/review-plan` round, each `/review-code` round.
+Sub-invocations: when `/implement` calls `/review-code`.
+
+### Save & Continue Protocol
+
+When context is ≥ 70%:
+1. Write a **continuation checkpoint** to PROJECT.md:
+   ```markdown
+   ## Continuation Checkpoint — [timestamp]
+   ### Current Command Chain
+   - Started: [first command]
+   - Completed: [commands finished so far]
+   - Next: [command to resume with, including any arguments/context]
+   ### State
+   - [Key decisions made]
+   - [Current scores/results if in review loop]
+   - [Files modified so far]
+   - [Any pending issues or blockers]
+   ```
+2. Commit any uncommitted work
+3. Run `/clear` to reset conversation context
+4. Run `/start` to reload PROJECT.md and pick up the checkpoint
+5. Continue with the next command/iteration in the chain automatically
+
+The user should not need to do anything — this is a seamless context refresh.
+
+### Why This Matters
+Auto-compaction silently drops earlier context, which can cause Claude to lose track of decisions, review scores, or chain state mid-workflow. Checkpointing preserves full fidelity.
 
 ## Communication Rules
 - **Be direct about errors** — no unnecessary apologies

--- a/skills/diagnose-ci/SKILL.md
+++ b/skills/diagnose-ci/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: diagnose-ci
+description: Known CI failure patterns, classification rules, and fix strategies for automated CI diagnosis.
+---
+
+# CI Failure Diagnosis
+
+You are diagnosing a CI failure. Match the failure against known patterns below, then classify your confidence and propose a fix.
+
+## Known Failure Patterns
+
+| Pattern | Symptoms | Fix | Confidence |
+|---------|----------|-----|------------|
+| **Stale TypeScript declarations** | `TS2305: Module has no exported member` after rename/move | Rebuild: `npm run build` or delete `dist/` and rebuild | HIGH |
+| **Missing dependencies** | `Cannot find module 'X'` in CI but works locally | Add to `package.json` / `requirements.txt`, run install | HIGH |
+| **Import path case mismatch** | Works on macOS (case-insensitive), fails on Linux CI | Fix the import path casing to match the actual filename | HIGH |
+| **Lint/format drift** | `eslint` or `prettier` failures on lines you didn't change | Run formatter (`npm run lint:fix`, `ruff format`), commit | HIGH |
+| **Flaky test — timing** | Test passes locally, fails in CI with timeout | Increase timeout or add `waitFor`/retry logic | MEDIUM |
+| **Flaky test — order-dependent** | Test fails only when run with full suite, passes alone | Find shared state (global, DB, env var), isolate it | MEDIUM |
+| **Cherry-pick residue** | Conflict markers (`<<<<<<<`) in committed files | Search and resolve remaining markers | HIGH |
+| **Missing env vars** | `undefined` or `KeyError` for config values | Add to CI config (`.github/workflows/`, `.env.ci`) | MEDIUM |
+| **Node version mismatch** | Syntax errors or API differences | Check `.nvmrc` / `engines` field vs CI node version | MEDIUM |
+| **Out-of-memory** | `FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed` | Reduce `maxWorkers`, add `--max-old-space-size` | HIGH |
+| **Lock file conflict** | `npm ci` fails with lockfile mismatch | Regenerate lockfile: `npm install`, commit `package-lock.json` | HIGH |
+
+## Analysis Steps
+
+1. **Read the full error output** — not just the first line
+2. **Identify the failing step** — build, test, lint, deploy?
+3. **Match against known patterns** above
+4. **If no match**: read the source files referenced in the error, check recent commits for relevant changes
+5. **Classify confidence**: HIGH (exact match), MEDIUM (likely match), LOW (novel)
+
+## Output Format
+
+For each failure:
+
+```markdown
+### Failure: [step name]
+
+**Error**: [key error message]
+**Pattern**: [matched pattern name, or "Novel"]
+**Confidence**: HIGH / MEDIUM / LOW
+**Root Cause**: [explanation]
+**Proposed Fix**: [specific fix with commands/code changes]
+**Verification**: [how to verify the fix locally]
+```


### PR DESCRIPTION
## Summary
- **Workflow chaining**: commands auto-continue through logical sequences (`/investigate` → `/create-plan` → `/review-plan` → `/finalize-plan` → GATE → `/implement`), with user gate only before implementation and publishing
- **Context management**: at chain boundaries/loop iterations, auto-checkpoint at ≥70% context depth (`/clear` → `/start` → resume), preventing silent auto-compaction from losing chain state
- **Friction fixes**: GitHub API reference in address-feedback, CHERRY_PICK_HEAD verification in cherry-pick, git history safety + pre-flight checks in implementation rules, worktree isolation in resource-management, permission-prompt-free `/start`
- **New commands**: `/diagnose-ci` (CI failure diagnosis with confidence-based auto-fix), `/review-code` (auto-fix local code review with loop until clean)
- **Rename**: `audit-tests` → `analyze-tests`

Based on Claude Code Insights report (1,632 messages, 183 sessions, March 6–20 2026).

## Test plan
- [ ] Run `/start` — should load PROJECT.md without any bash permission prompts
- [ ] Run `/create-plan` on a test task — should auto-chain into `/review-plan` then `/finalize-plan` then stop
- [ ] Verify `/review-plan` iterates past 3 rounds if scores are below 8/10
- [ ] Run `/review-code` on uncommitted changes — should loop until only nitpicks remain
- [ ] Run `/diagnose-ci` on a failed CI run — should classify and propose fixes by confidence
- [ ] Verify `/analyze-tests` works (renamed from `/audit-tests`)
- [ ] Trace bug fix chain: `/investigate` should auto-chain all the way through `/finalize-plan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)