### PR TITLE
feat: add PGM toolkit for program health and velocity reporting

### DIFF
--- a/commands/create-report.md
+++ b/commands/create-report.md
@@ -6,6 +6,13 @@
 > **When**: Before meetings, weekly check-ins, or anytime you need a current snapshot of program health.
 > **Produces**: Program health report with epic progress, flow health, risks, blockers, and team state.
 
+## Pre-flight
+
+This command is data-heavy — agents return large synthesized results. Before starting:
+1. If there's meaningful prior work in context, update PROJECT.md with current state
+2. If context is above ~50%, run `/clear` first — you need room for the report AND follow-up conversation
+3. Then proceed with Step 1
+
 ## Usage
 
 ```

--- a/commands/create-report.md
+++ b/commands/create-report.md
@@ -1,5 +1,6 @@
 # /create-report — Live Program Health Report
 
+@/Users/joeli/opt/code/claude-rules/rules/universal.md
 @/Users/joeli/opt/code/claude-rules/rules/pgm.md
 @/Users/joeli/opt/code/claude-rules/rules/api.md
 
@@ -8,9 +9,9 @@
 
 ## Pre-flight
 
-This command is data-heavy — agents return large synthesized results. Before starting:
-1. If there's meaningful prior work in context, update PROJECT.md with current state
-2. If context is above ~50%, run `/clear` first — you need room for the report AND follow-up conversation
+This command is data-heavy — agents return large synthesized results. Before starting, follow the **Context Management** protocol from `rules/universal.md`:
+1. If context is at or above ~70%, write a **continuation checkpoint** to PROJECT.md (including the `/create-report` arguments), commit, then `/clear` → `/start` to resume
+2. If context is below ~70% but above ~50%, check whether the report data + follow-up conversation will fit — if tight, checkpoint and clear
 3. Then proceed with Step 1
 
 ## Usage
@@ -59,8 +60,8 @@ Handle pagination on all search calls. Filter out bot-owned stories.
 
 Run all repo queries in **parallel bash calls** (each repo is independent):
 - For each of the 3 repos, in parallel:
-  - **Open PRs**: `gh pr list -R <repo> --state open --json number,title,author,createdAt,reviewDecision,url,labels`
-  - **Recently merged**: `gh pr list -R <repo> --state merged --json number,title,author,mergedAt,url --search "merged:>YYYY-MM-DD"` (14 days ago)
+  - **Open PRs**: `gh pr list -R <repo> --state open --limit 100 --json number,title,author,createdAt,reviewDecision,url,labels`
+  - **Recently merged**: `gh pr list -R <repo> --state merged --limit 200 --json number,title,author,mergedAt,url --search "merged:>YYYY-MM-DD"` (14 days ago)
 
 That's 6 independent gh calls (2 per repo) — run them all in parallel.
 

--- a/commands/create-report.md
+++ b/commands/create-report.md
@@ -1,0 +1,134 @@
+# /create-report — Live Program Health Report
+
+@/Users/joeli/opt/code/claude-rules/rules/pgm.md
+@/Users/joeli/opt/code/claude-rules/rules/api.md
+
+> **When**: Before meetings, weekly check-ins, or anytime you need a current snapshot of program health.
+> **Produces**: Program health report with epic progress, flow health, risks, blockers, and team state.
+
+## Usage
+
+```
+/create-report                         # All teams
+/create-report "Producks"              # One team
+/create-report --epic "auth migration" # One epic across teams
+```
+
+## Steps
+
+### 1. Load Context
+
+- Read `/Users/joeli/opt/code/pgm/config.json` for team UUIDs, member list, bot accounts, repo mapping
+- Parse arguments: team filter, epic filter, or all teams
+- Set date context: today's date for "current state", last 14 days for "recently shipped"
+
+### 2. Gather Data (Parallel Agents)
+
+Use the **Agent tool** to spawn 2-3 agents **in a single message** (this is critical — multiple Agent tool calls in one message run concurrently). Each agent prompt must include instructions to:
+- Read `/Users/joeli/opt/code/claude-rules/rules/pgm.md` for API patterns
+- Read `/Users/joeli/opt/code/pgm/config.json` for team UUIDs, members, bots
+- Return structured JSON or markdown that the main context can synthesize
+
+**Agent 1 — Shortcut REST API** (via `curl` with `$SHORTCUT_API_TOKEN`):
+
+Run all team queries in **parallel bash calls** (each team's queries are independent):
+- **WIP stories** per team: `POST /stories/search` with `workflow_state_types: ["started"]` and `group_id`
+  - Flag stories where `moved_at` > 5 days ago as stalled
+  - Flag stories where `blocked == true` or `blocker == true`
+  - Calculate WIP count per team member (from `owner_ids`)
+- **Recently completed** per team: `POST /stories/search` with `completed_at_start` (14 days ago) and `group_id`
+  - Include `cycle_time`, `story_type`, `epic_id`, `estimate`
+
+That's 6 independent curl calls (2 per team) — run them all in parallel.
+
+Then, from the results:
+- **Epic details**: Collect unique `epic_id` values, then fetch `GET /epics/{id}` for each — these are also independent, run in parallel
+  - Track completion percentage, state, remaining story count
+- **Workflow states**: `GET /workflows` once to map state IDs → readable names
+
+Handle pagination on all search calls. Filter out bot-owned stories.
+
+**Agent 2 — GitHub CLI** (via `gh`):
+
+Run all repo queries in **parallel bash calls** (each repo is independent):
+- For each of the 3 repos, in parallel:
+  - **Open PRs**: `gh pr list -R <repo> --state open --json number,title,author,createdAt,reviewDecision,url,labels`
+  - **Recently merged**: `gh pr list -R <repo> --state merged --json number,title,author,mergedAt,url --search "merged:>YYYY-MM-DD"` (14 days ago)
+
+That's 6 independent gh calls (2 per repo) — run them all in parallel.
+
+Then aggregate:
+- Flag PRs open > 48 hours without approved review
+- Filter out bot authors from `config.json` bots list
+- Count review backlog: PRs where `reviewDecision` is empty or "REVIEW_REQUIRED"
+
+**Agent 3 — Notion MCP** (optional, skip gracefully if nothing found):
+- `notion-search` for recent meeting notes, prior program reports, or open action items
+- Only include if results are directly relevant
+- If no Notion results, return empty — don't block on this
+
+### 3. Synthesize Report
+
+Combine agent results into a structured report:
+
+```markdown
+# Program Health — [date]
+[Team filter if applicable]
+
+## Epic Progress
+For each active epic:
+- **[Epic name]** — [X/Y stories done] — [status: on track / at risk / blocked]
+  - [Key recent completions]
+  - [Remaining work summary]
+  - [Risk if any]
+
+## Flow Health
+- **WIP**: [total] across [teams] ([per-team breakdown])
+  - [Flag if any team > 2× member count]
+- **Cycle Time**: [median] days (last 14 days)
+- **Throughput**: [count] stories completed in last 14 days
+- **Stalled**: [count] stories with no movement > 5 days
+  - [List each with owner and current state]
+
+## Risks & Blockers
+Auto-detected from signals:
+- Blocked stories (from Shortcut `blocked`/`blocker` fields)
+- Stalled work (no state change > 5 days)
+- Review backlog (PRs pending review > 48h)
+- High WIP (team WIP > 2× team size)
+- Epics at risk (low completion rate vs timeline)
+
+For each risk:
+- **[Risk]** — [Impact] — [Owner/Team] — [Suggested action]
+
+## Team State
+Per team:
+- **[Team name]** — [WIP count] in progress, [completed count] shipped (14d)
+  - [Who's working on what — from story owners]
+  - [Capacity signals — anyone overloaded (>3 WIP items)?]
+
+## PR State
+- **Open**: [count] across repos ([count] awaiting review > 48h)
+- **Merged (14d)**: [count]
+- **Review backlog**: [list PRs needing attention]
+
+## Recently Shipped
+- [Story/PR name] — [team] — [completed date]
+  (Group by team, most recent first, limit to ~10 most notable)
+```
+
+### 4. Present & Follow Up
+
+Present the report. Suggest follow-up actions:
+
+- "Summarize this for execs" → uses `pgm-comms` skill with `executive` audience
+- "What are the biggest risks?" → deeper analysis from report data
+- "Write a status update" → uses `pgm-comms` with appropriate audience
+- "Focus on [team/epic]" → filter and expand that section
+
+## Notes
+
+- This is a **live snapshot** — data is current as of query time, not historical
+- For historical metrics and trends, use `/velocity-report` instead
+- The report identifies risks from signals but doesn't prescribe solutions — that's a conversation
+- If Shortcut API is unavailable, fall back to Shortcut MCP tools (slower, permission prompts)

--- a/commands/investigate.md
+++ b/commands/investigate.md
@@ -1,11 +1,37 @@
 # /investigate - Investigation & Root Cause
 
 @/Users/joeli/opt/code/claude-rules/rules/investigation.md
+@/Users/joeli/opt/code/claude-rules/rules/api.md
 
 > **When**: Something is broken and you need to find why.
 > **Produces**: Root cause analysis documented in PROJECT.md, validated by review-rca skill.
 
+## Usage
+```
+/investigate "the login page is broken"          # Describe the problem
+/investigate sc-12345                             # Start from a Shortcut story
+/investigate apache/superset#28456               # Start from a GitHub issue
+/investigate https://github.com/.../issues/123   # Start from a GitHub URL
+/investigate https://app.shortcut.com/...        # Start from a Shortcut URL
+```
+
 ## Steps
+
+0. **Fetch External Context (if reference provided)**
+
+   Use the Input Detection table in `rules/api.md` to identify the source type from the argument.
+
+   **Shortcut story** (`sc-12345`, Shortcut URL):
+   - Query the story via Shortcut REST API (see `api.md`)
+   - Extract: title, description, acceptance criteria, labels, story type, linked PRs (`external_links`), comments, epic context
+   - Use the description and comments to understand what's broken and any prior investigation
+
+   **GitHub issue/PR** (`#12345`, `owner/repo#12345`, GitHub URL):
+   - Query via `gh issue view` or `gh pr view` (see `api.md`)
+   - Extract: title, body, labels, linked PRs, comments, repro steps
+   - Check for linked Shortcut stories in the body/comments
+
+   Fold the extracted context into the problem documentation in Step 1.
 
 1. **Document the Problem**
    ```markdown

--- a/commands/pgm-comms.md
+++ b/commands/pgm-comms.md
@@ -1,0 +1,21 @@
+# /pgm-comms — Format for Audience
+
+@/Users/joeli/opt/code/claude-rules/skills/pgm/comms/SKILL.md
+
+> **When**: After generating a report or gathering program data, format it for a specific audience.
+> **Produces**: Audience-formatted output (executive, delivery, eng+QA, cross-functional, broad stakeholder, or escalation).
+
+## Usage
+
+```
+/pgm-comms executive           # Format recent report/context for execs
+/pgm-comms delivery            # Format for delivery team
+/pgm-comms escalation "auth"   # Escalation about a specific topic
+```
+
+## Steps
+
+1. **Identify source data**: Use the most recent report, status update, or program data in the current conversation. If none exists, tell the user to run `/create-report` or `/velocity-report` first. If a trailing argument is provided after the audience (e.g., `"auth"`), use it as a topic filter — focus the formatted output on that topic/epic/area.
+2. **Determine audience**: From the argument, or infer from context (see SKILL.md rules).
+3. **Format**: Apply the audience template and rules from the loaded `pgm-comms` skill.
+4. **Present**: Output the formatted content, ready to copy/paste.

--- a/commands/velocity-report.md
+++ b/commands/velocity-report.md
@@ -6,6 +6,13 @@
 > **When**: End of month (or anytime you need historical velocity metrics).
 > **Produces**: Full velocity report with throughput, cycle times, PR metrics, and team breakdowns.
 
+## Pre-flight
+
+This command is data-heavy — pipeline output and follow-up analysis need context room. Before starting:
+1. If there's meaningful prior work in context, update PROJECT.md with current state
+2. If context is above ~50%, run `/clear` first — you need room for the report AND follow-up conversation
+3. Then proceed with Step 1
+
 ## Usage
 
 ```

--- a/commands/velocity-report.md
+++ b/commands/velocity-report.md
@@ -1,5 +1,6 @@
 # /velocity-report — Monthly Velocity Metrics
 
+@/Users/joeli/opt/code/claude-rules/rules/universal.md
 @/Users/joeli/opt/code/claude-rules/rules/pgm.md
 @/Users/joeli/opt/code/claude-rules/rules/api.md
 
@@ -8,9 +9,9 @@
 
 ## Pre-flight
 
-This command is data-heavy — pipeline output and follow-up analysis need context room. Before starting:
-1. If there's meaningful prior work in context, update PROJECT.md with current state
-2. If context is above ~50%, run `/clear` first — you need room for the report AND follow-up conversation
+This command is data-heavy — pipeline output and follow-up analysis need context room. Before starting, follow the **Context Management** protocol from `rules/universal.md`:
+1. If context is at or above ~70%, write a **continuation checkpoint** to PROJECT.md (including the `/velocity-report` arguments like `--month`), commit, then `/clear` → `/start` to resume
+2. If context is below ~70% but above ~50%, check whether the pipeline output + follow-up conversation will fit — if tight, checkpoint and clear
 3. Then proceed with Step 1
 
 ## Usage

--- a/commands/velocity-report.md
+++ b/commands/velocity-report.md
@@ -1,0 +1,98 @@
+# /velocity-report — Monthly Velocity Metrics
+
+@/Users/joeli/opt/code/claude-rules/rules/pgm.md
+@/Users/joeli/opt/code/claude-rules/rules/api.md
+
+> **When**: End of month (or anytime you need historical velocity metrics).
+> **Produces**: Full velocity report with throughput, cycle times, PR metrics, and team breakdowns.
+
+## Usage
+
+```
+/velocity-report                       # Current month from config.json
+/velocity-report --month 2026-03       # Specific month
+/velocity-report --summary-only        # Exec summary from existing metrics.json
+```
+
+## Steps
+
+### 1. Load Context
+
+- Read `/Users/joeli/opt/code/pgm/config.json` for current `month`, `date_range`, teams, members, repos
+- If `--month` provided and differs from config, tell the user to update `config.json` first (the pipeline reads config directly)
+- If `--summary-only`, skip to Step 5
+
+### 2. Read Pipeline Instructions
+
+- Read `/Users/joeli/opt/code/pgm/run.md` for the full pipeline instructions
+- Follow those instructions — they are the authoritative source for how the pipeline runs
+
+### 3. Execute Pipeline
+
+Follow the steps in `run.md`:
+
+**3a. Start GitHub collection in background:**
+```bash
+cd /Users/joeli/opt/code/pgm && python3 collect_github.py
+```
+This takes ~5-10 min. Continue to 3b while it runs.
+
+**3b. Collect Shortcut data (while GitHub runs in background):**
+
+Use the Shortcut REST API (preferred) via `curl` with `$SHORTCUT_API_TOKEN`.
+
+Run all team queries in **parallel bash calls** — each team's queries are independent:
+- **Completed stories** per team: `POST /stories/search` with `completed_at_start`/`completed_at_end` from config date range, `group_id`
+- **WIP snapshot** per team: `POST /stories/search` with `workflow_state_types: ["started"]`, `group_id`
+
+That's 6 independent curl calls (2 per team × 3 teams) — run them all in parallel in a single message. Handle pagination on each.
+
+Also collect:
+- **Iterations**: overlapping the target month
+- **Epics**: for all unique `epic_id` values found in completed stories
+
+Save to `data/{month}/`:
+- `raw_stories.json` — all completed stories
+- `raw_wip.json` — all WIP stories
+- `raw_iterations.json` — iteration objects
+- `raw_epics.json` — epic objects
+
+**3c. Wait for GitHub collection to finish.**
+
+**3d. Run processing pipeline sequentially:**
+```bash
+cd /Users/joeli/opt/code/pgm && python3 collect_shortcut.py
+cd /Users/joeli/opt/code/pgm && python3 analyze.py
+cd /Users/joeli/opt/code/pgm && python3 report.py
+```
+
+### 4. Validate Output
+
+Read `data/{month}/report.md` and `data/{month}/metrics.json`.
+
+Flag data quality issues:
+- Teams with 0 completed stories (collection may have failed)
+- Negative cycle time values (timestamp issues)
+- Individual PR counts that seem too high or low vs team size
+- Large numbers of unlinked stories/PRs (Shortcut ↔ GitHub linkage gaps)
+
+### 5. Present Report
+
+Read and present `data/{month}/report.md` to the user.
+
+If `--summary-only`: read `data/{month}/metrics.json` and produce a concise executive summary using `pgm-comms` with `executive` audience.
+
+Suggest follow-up actions:
+- "What trends do you see?" → analyze metrics.json for patterns
+- "Compare to last month" → read prior month's `data/{prev-month}/metrics.json` if it exists
+- "Summarize for leadership" → uses `pgm-comms` with `executive` audience
+- "Who's blocked?" / "Where are the bottlenecks?" → dig into specifics from raw data
+- "Break this down by team" → team-level analysis from metrics.json
+
+## Notes
+
+- This wraps the existing Python pipeline in `/Users/joeli/opt/code/pgm/`
+- The pipeline is the authoritative source for metric calculations — don't reimplement metrics manually
+- For live/current-state data, use `/create-report` instead
+- If the pipeline fails, read the error output and diagnose — don't silently skip steps
+- Raw data files can be re-analyzed without re-collecting: skip to Step 3d if `raw_*.json` files already exist for the month

--- a/install.sh
+++ b/install.sh
@@ -152,9 +152,9 @@ ls "$REPO_DIR/commands"/*.md 2>/dev/null | xargs -I {} basename {} .md | sort | 
 done
 echo ""
 info "Available skills ($SKILL_COUNT):"
-find "$REPO_DIR/skills" -name "SKILL.md" -exec dirname {} \; 2>/dev/null | xargs -I {} basename {} | sort | while read skill; do
-    echo "  $skill"
-done
+find "$REPO_DIR/skills" -name "SKILL.md" -exec dirname {} \; 2>/dev/null | while read dir; do
+    echo "  ${dir#$REPO_DIR/skills/}"
+done | sort
 echo ""
 info "To start using Claude Code with your new config:"
 echo "  claude"

--- a/rules/api.md
+++ b/rules/api.md
@@ -9,11 +9,11 @@ Single source of truth for all external tool integrations. Commands reference th
 ### PR Operations
 
 ```bash
-# List open PRs
-gh pr list -R <owner>/<repo> --state open --json number,title,author,createdAt,reviewDecision,url,labels
+# List open PRs (default limit is 30 — raise for reports)
+gh pr list -R <owner>/<repo> --state open --limit 100 --json number,title,author,createdAt,reviewDecision,url,labels
 
-# List merged PRs (by date)
-gh pr list -R <owner>/<repo> --state merged --json number,title,author,mergedAt,url --search "merged:>YYYY-MM-DD"
+# List merged PRs (by date — raise limit for monthly reports)
+gh pr list -R <owner>/<repo> --state merged --limit 200 --json number,title,author,mergedAt,url --search "merged:>YYYY-MM-DD"
 
 # View PR metadata
 gh pr view <number-or-url> --json title,body,author,baseRefName,headRefName,files,additions,deletions

--- a/rules/api.md
+++ b/rules/api.md
@@ -1,0 +1,205 @@
+# External API Reference
+
+Single source of truth for all external tool integrations. Commands reference this via `@` instead of duplicating patterns.
+
+## GitHub CLI (`gh`)
+
+**Auth**: `$GITHUB_TOKEN` (used by `gh` CLI automatically)
+
+### PR Operations
+
+```bash
+# List open PRs
+gh pr list -R <owner>/<repo> --state open --json number,title,author,createdAt,reviewDecision,url,labels
+
+# List merged PRs (by date)
+gh pr list -R <owner>/<repo> --state merged --json number,title,author,mergedAt,url --search "merged:>YYYY-MM-DD"
+
+# View PR metadata
+gh pr view <number-or-url> --json title,body,author,baseRefName,headRefName,files,additions,deletions
+
+# Get the diff
+gh pr diff <number-or-url>
+
+# List changed file paths
+gh pr view <number-or-url> --json files -q '.files[].path'
+
+# Get diff hunks with positions (for inline review comments)
+gh api repos/<owner>/<repo>/pulls/<number>/files --paginate
+```
+
+### PR Review & Comments
+
+```bash
+# View PR comments
+gh pr view <number> --comments
+
+# List code-level review comments
+gh api repos/<owner>/<repo>/pulls/<number>/comments
+
+# List general PR comments (issue-level)
+gh api repos/<owner>/<repo>/issues/<number>/comments
+
+# Submit a review with inline comments
+gh api repos/<owner>/<repo>/pulls/<number>/reviews \
+  -f event="REQUEST_CHANGES" \
+  -f body="Review summary" \
+  -f 'comments[]={ "path": "file.py", "line": 42, "body": "[major] description" }'
+
+# Submit a simple review (approve / request changes / comment)
+gh pr review <number> --approve --body "LGTM"
+gh pr review <number> --request-changes --body "See comments"
+gh pr review <number> --comment --body "Some thoughts"
+
+# Reply to a specific review comment
+gh api repos/<owner>/<repo>/pulls/comments/<comment-id>/replies \
+  -f body="<response>"
+
+# Post a general PR comment
+gh pr comment <number> --body "<response>"
+```
+
+### CI Operations
+
+```bash
+# List recent failed runs on a branch
+gh run list --branch <branch> --status failure --limit 1
+
+# View failed run logs
+gh run view <run-id> --log-failed
+
+# Check PR CI status
+gh pr checks <number>
+```
+
+### Issue Operations
+
+```bash
+# View an issue
+gh issue view <number-or-url> -R <owner>/<repo> --json title,body,author,labels,state,comments
+
+# Search issues
+gh api search/issues -X GET -f q="repo:<owner>/<repo> is:issue <query>"
+
+# Search PRs waiting for review
+gh api search/issues -X GET -f q="repo:<owner>/<repo> is:pr is:open review:required"
+```
+
+### Cherry-Pick Support
+
+```bash
+# Get merge commit and files from a PR
+gh pr view <number-or-url> --json mergeCommit,files
+
+# View commit context
+git show --stat <commit-hash>
+```
+
+## Shortcut REST API
+
+**Auth**: `Shortcut-Token: $SHORTCUT_API_TOKEN` header
+**Base URL**: `https://api.app.shortcut.com/api/v3`
+
+**When to use**: Bulk data gathering, automated pipelines, parallel collection. Faster than MCP, no permission prompts, richer fields.
+
+### Endpoints
+
+| Endpoint | Method | Use |
+|----------|--------|-----|
+| `/stories/search` | POST | Find stories by team, state, dates. Supports pagination. |
+| `/stories/<id>` | GET | Single story details |
+| `/epics/<id>` | GET | Epic details — progress, state, stories |
+| `/groups` | GET | All teams (groups) — verify UUIDs |
+| `/groups/<id>/stories` | GET | Stories assigned to a team |
+| `/iterations` | GET | All iterations |
+| `/workflows` | GET | Workflow states — map state IDs to names |
+| `/members` | GET | All workspace members |
+
+### Common Query Patterns
+
+**Completed stories by team in a date range:**
+```bash
+curl -s -X POST "https://api.app.shortcut.com/api/v3/stories/search" \
+  -H "Content-Type: application/json" \
+  -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
+  -d '{"completed_at_start":"2026-03-01T00:00:00Z","completed_at_end":"2026-03-21T23:59:59Z","group_id":"<team-uuid>"}'
+```
+
+**WIP stories (in progress) by team:**
+```bash
+curl -s -X POST "https://api.app.shortcut.com/api/v3/stories/search" \
+  -H "Content-Type: application/json" \
+  -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
+  -d '{"workflow_state_types":["started"],"group_id":"<team-uuid>"}'
+```
+
+**Blocked stories (filter from WIP results):**
+```bash
+# Query WIP, then filter client-side:
+| jq '[.data[] | select(.blocked == true or .blocker == true)]'
+```
+
+**Single story by ID:**
+```bash
+curl -s "https://api.app.shortcut.com/api/v3/stories/<story-id>" \
+  -H "Shortcut-Token: $SHORTCUT_API_TOKEN"
+```
+
+**Epic details:**
+```bash
+curl -s "https://api.app.shortcut.com/api/v3/epics/<epic-id>" \
+  -H "Shortcut-Token: $SHORTCUT_API_TOKEN"
+```
+
+### Key Story Fields
+
+`name`, `id`, `app_url`, `story_type` (feature/bug/chore), `workflow_state_id`, `group_id`, `epic_id`, `estimate`, `owner_ids`, `labels`, `completed_at`, `started_at`, `moved_at`, `cycle_time`, `lead_time`, `blocked`, `blocker`, `external_links` (GitHub PR URLs), `custom_fields`
+
+### Pagination
+
+Search responses include a `next` token when more results exist. Pass it as `"next": "<token>"` in subsequent POST body. Loop until no `next` token is returned.
+
+### Workflow States
+
+Fetch from `/workflows` to map `workflow_state_id` → human-readable names. The "Engineering Kanban" workflow is primary. Typical flow: Unstarted → Ready for Dev → In Development → Ready for Review → In Review → Ready for Deploy → Deployed/Done.
+
+### Story ID Formats
+
+Stories can be referenced as:
+- `sc-12345` or `SC-12345` — extract the number, query `/stories/12345`
+- Shortcut URL — extract the story ID from the path
+- Numeric ID — query directly
+
+## Shortcut MCP
+
+**When to use**: Interactive queries, one-off lookups, when REST API is unavailable. Slower than REST, triggers permission prompts.
+
+| Tool | Use |
+|------|-----|
+| `stories-search` | Search with team, date, state filters |
+| `stories-get-by-id` | Single story details |
+| `epics-get-by-id` | Epic details |
+| `epics-search` | Find epics by query |
+| `iterations-search` | Find iterations by date range |
+| `iterations-get-stories` | Stories in an iteration |
+
+## Notion MCP
+
+**When to use**: Interactive only — docs, meeting notes, databases. Not for bulk data.
+
+| Tool | Use |
+|------|-----|
+| `notion-search` | Find pages by title/content |
+| `notion-fetch` | Read a specific page or database |
+
+## Input Detection
+
+When a command receives an argument, detect the source type:
+
+| Input Pattern | Source | Action |
+|---------------|--------|--------|
+| `sc-12345` or `SC-12345` | Shortcut story | Query Shortcut REST API `/stories/12345` |
+| `https://app.shortcut.com/...` | Shortcut URL | Extract story/epic ID, query REST API |
+| `#12345` or `12345` (with repo context) | GitHub issue/PR | `gh issue view` or `gh pr view` |
+| `owner/repo#12345` | GitHub issue/PR | `gh issue view 12345 -R owner/repo` |
+| `https://github.com/...` | GitHub URL | `gh issue view <url>` or `gh pr view <url>` |

--- a/rules/pgm.md
+++ b/rules/pgm.md
@@ -1,0 +1,85 @@
+# Program Management Context
+
+@/Users/joeli/opt/code/claude-rules/rules/api.md
+
+## Org Structure
+
+Joe Li is an EM running 3 teams on kanban across 3 repos. Teams use flow-based delivery — frame everything around WIP, cycle time, throughput, and blockers. Not sprints.
+
+### Teams
+
+| Team | Shortcut Group ID | Mention Name | Repo Focus |
+|------|-------------------|--------------|------------|
+| Producks | `5fc58cd7-0bce-4412-820f-26e75af61e5a` | `engineering` | apache/superset (features, UI) |
+| Pladopi | `67ad4529-6cca-45f8-a516-42a2bad75f93` | `platform-devops` | preset-io/manager, preset-io/superset-shell |
+| Supernauts | `696a884d-23ba-44b5-8e7f-5c7e4ba32f4d` | `supernauts` | apache/superset (onboarding, enablement) |
+
+### Member Resolution
+
+**Canonical source**: `/Users/joeli/opt/code/pgm/config.json`
+
+Always read `config.json` for the full member list with GitHub handles, Shortcut IDs, team assignments, and notes (QA, PM, Designer, EM roles). Do not hardcode member lists — the config is the source of truth.
+
+Bot accounts to filter from metrics: listed in `config.json` under `bots`.
+
+### Repo Mapping
+
+| Repo | Strategy | Local Path |
+|------|----------|------------|
+| `apache/superset` | `per_member` — query by team member GitHub handles | `/Users/joeli/opt/code/superset-release` |
+| `preset-io/superset-shell` | `all_prs` — query all PRs in date range | `/Users/joeli/opt/code/superset-shell` |
+| `preset-io/manager` | `all_prs` — query all PRs in date range | `/Users/joeli/opt/code/manager` |
+
+## API Reference
+
+See `rules/api.md` for all API patterns (Shortcut REST, GitHub CLI, Notion MCP, Shortcut MCP). For PGM commands, prefer Shortcut REST API over MCP — faster, no permission prompts, richer fields.
+
+## Parallel Agent Pattern
+
+When gathering data from multiple sources, spawn concurrent agents to maximize throughput:
+
+```
+Agent 1 (Shortcut REST API):
+  - Completed stories per team (POST /stories/search with completed_at filters)
+  - WIP stories per team (workflow_state_types: started)
+  - Blocked/blocker stories
+  - Epic details for referenced epics
+  - Calculate: WIP per member, stalled stories (moved_at > 5 days ago), type distribution
+
+Agent 2 (GitHub CLI):
+  - Open PRs per repo (flag those > 48h without review)
+  - Recently merged PRs
+  - Review backlog
+
+Agent 3 (Notion MCP, optional):
+  - Prior reports or meeting notes
+  - Open action items
+  - Skip gracefully if nothing relevant found
+```
+
+Each agent should:
+- Read `config.json` for team/member context
+- Filter out bot accounts
+- Return structured data for synthesis
+
+## Audience Tiers
+
+Used by `pgm-comms` skill for formatting. Referenced here so commands know what audience modes are available.
+
+| Audience | Focus | Tone |
+|----------|-------|------|
+| **Executive** | Impact, decisions needed, timeline | Brief, outcome-oriented |
+| **Cross-functional** | Dependencies, risks, team highlights | Collaborative, actionable |
+| **Delivery** | Board health, blockers, what shipped/next | Direct, owner-tagged |
+| **Eng+QA** | PRs, test signals, build health, tech debt | Technical, specific |
+| **Broad stakeholder** | What launched, user impact, milestones | Accessible, celebratory |
+| **Escalation** | What's at risk, what's been tried, the ask | Urgent, structured |
+
+## Data Collection Rules
+
+1. **Always paginate** — Shortcut search results may span multiple pages
+2. **Filter bots** — exclude accounts listed in `config.json` `bots` array from all metrics
+3. **State query date** — use today's date for "current state" queries, config dates for historical
+4. **Stale threshold** — stories with `moved_at` > 5 days ago and still in progress are flagged as stalled
+5. **PR age threshold** — open PRs without review activity > 48 hours are flagged
+6. **Cycle time source** — use `cycle_time` field from Shortcut (seconds), convert to days for display

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -27,6 +27,8 @@
 | CI build failed | CI Diagnosis | `/diagnose-ci` |
 | Pre-commit quality pass | Self Review | `/review-code` |
 | PR has review comments | PR Feedback | `/address-feedback` |
+| Program health snapshot | PGM Report | `/create-report` |
+| Monthly velocity metrics | Velocity | `/velocity-report` |
 
 **GATE** = user reviews and manually triggers next step.
 
@@ -95,4 +97,6 @@ Auto-compaction silently drops earlier context, which can cause Claude to lose t
 | `resource-management.md` | Docker limits, test worker scaling |
 | `cherry-picking.md` | Cross-branch work |
 | `code-review.md` | Review guidelines, scoring |
+| `api.md` | External API reference: GitHub CLI, Shortcut REST, Notion MCP |
+| `pgm.md` | Program management: org context, audience tiers, data collection rules |
 

--- a/skills/pgm/comms/SKILL.md
+++ b/skills/pgm/comms/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: pgm-comms
+description: Format program management content for a specific audience tier — executive, cross-functional, delivery, eng+QA, broad stakeholder, or escalation.
+---
+
+# Communication Formatting
+
+You are formatting program management content for a specific audience. Transform the input (report data, status updates, risk summaries, etc.) into audience-appropriate output.
+
+## Usage
+
+```
+/pgm-comms executive          # Format for exec audience
+/pgm-comms delivery           # Format for delivery team
+/pgm-comms escalation         # Format for escalation
+```
+
+If no audience is specified, infer from context:
+- "summarize for leadership" → executive
+- "update the team" → delivery
+- "this needs to be escalated" → escalation
+- Unclear → ask
+
+## Audience Templates
+
+### Executive
+
+```markdown
+**TL;DR**: [One sentence — what matters most right now]
+
+**Status**: 🟢 On Track / 🟡 At Risk / 🔴 Blocked
+
+**Impact**: [What this means for the business/product/users]
+
+**Decisions Needed**:
+- [Decision 1 — with recommendation]
+
+**Timeline**: [Key dates or milestones]
+```
+
+**Rules**: No task lists. No technical jargon. No individual story details. Lead with impact. If there's nothing to decide, say so — execs value knowing their attention isn't needed.
+
+### Cross-Functional Leadership
+
+```markdown
+## Summary
+[2-3 sentences — what's happening across teams]
+
+## Team Highlights
+- **[Team]**: [Key accomplishment or focus area]
+
+## Dependencies & Risks
+- [Dependency/risk with owning team and status]
+
+## Asks
+- [What you need from other teams/stakeholders]
+```
+
+**Rules**: Balance detail across teams — don't let one team dominate. Flag cross-team dependencies explicitly. Every risk needs an owner.
+
+### Delivery Team
+
+```markdown
+## Board Health
+- **WIP**: [count] items in progress ([assessment])
+- **Blocked**: [count] items ([brief details])
+- **Stalled**: [count] items with no movement > 5 days
+
+## Blockers
+| Item | Owner | Blocked Since | Action Needed |
+|------|-------|---------------|---------------|
+
+## What Shipped
+- [Item] — [who]
+
+## What's Next
+- [Item] — [who]
+
+## Action Items
+- [ ] [Action] — @[owner] — [due]
+```
+
+**Rules**: Every blocker needs an owner and action. Every "what's next" needs a name attached. No vague summaries — be specific about who's doing what.
+
+### Eng+QA
+
+```markdown
+## Technical Status
+[What's actively being built/tested]
+
+## PR State
+- **Open**: [count] ([count] awaiting review > 48h)
+- **Merged this period**: [count]
+- **Review backlog**: [details]
+
+## Test & Build Health
+[CI status, flaky tests, test coverage signals]
+
+## Tech Debt / Risks
+- [Technical risk or debt item with impact]
+```
+
+**Rules**: Include PR links where relevant. Be specific about CI/test state. Technical audience — use precise language, no hand-waving.
+
+### Broad Stakeholder
+
+```markdown
+## What Launched
+- **[Feature/Fix]**: [User-facing impact in plain language]
+
+## Coming Up
+- [Milestone] — [expected timing]
+
+## How This Helps
+[Connect technical work to user/business value]
+```
+
+**Rules**: No internal jargon (no "stories", "epics", "PRs"). Translate everything to user impact. Celebrate wins — this audience needs to see momentum.
+
+### Escalation
+
+```markdown
+## What's At Risk
+[One sentence — the thing that's at risk and why it matters]
+
+## Business Impact
+[Quantify if possible — users affected, revenue impact, timeline slip]
+
+## What We've Tried
+1. [Action taken] — [result]
+2. [Action taken] — [result]
+
+## The Ask
+**[Specific decision or support needed]**
+[Options if applicable, with trade-offs]
+
+## Timeline
+- **If we act by [date]**: [outcome]
+- **If not**: [consequence]
+```
+
+**Rules**: Never bury the ask. Lead with what's at risk, not background. "What we've tried" proves you've done your homework. Always include a timeline with consequences.
+
+## Anti-Patterns (applies across all audiences)
+
+- **Don't pad with filler** — if there's nothing to report for a section, omit it
+- **Don't mix audiences** — exec summary + task-level details = neither audience is served
+- **Don't use passive voice for risks** — "the deadline might be missed" → "we will miss the deadline unless [action]"
+- **Don't list without context** — "5 stories completed" means nothing without "which means the auth migration is 80% done"
+- **Don't hedge without data** — "things seem okay" → "cycle time is 3.2 days, WIP is within limits, no blockers"
+
+## Working Rules
+
+- Match the format exactly — audiences develop expectations
+- Use real names and real numbers — vagueness erodes trust
+- If the input data is incomplete, say what's missing rather than papering over gaps
+- Keep it scannable — headers, bullets, tables over paragraphs
+- One message, one audience — if you need multiple audiences, produce multiple outputs


### PR DESCRIPTION
## Summary
- **Two new commands**: `/create-report` (live program health via parallel Shortcut REST + GitHub CLI agents) and `/velocity-report` (monthly metrics wrapping the existing Python pipeline)
- **Shared API reference** (`rules/api.md`): consolidated GitHub CLI, Shortcut REST, Notion MCP patterns — single file to update when switching tools (e.g., Shortcut → Jira)
- **Comms skill + command** (`skills/pgm/comms` + `commands/pgm-comms.md`): audience-tailored formatting for exec, delivery, eng+QA, escalation, cross-functional, and broad stakeholder audiences — now wired as a real `/pgm-comms` slash command
- **Updated `/investigate`**: now accepts Shortcut story IDs (`sc-12345`) and GitHub issue URLs as input, fetching context before investigation

### Review follow-ups (c4b5ba4)
- Pre-flight context checks now use the checkpoint protocol from `universal.md` instead of ad-hoc `/clear`
- `gh pr list` calls include explicit `--limit` to avoid silent undercounting (default is 30)
- `install.sh` prints relative skill paths (`pgm/comms` not `comms`) to avoid namespace collisions
- PGM commands explicitly `@`-include `universal.md` so the checkpoint protocol is loaded, not just referenced

## Test plan
- [ ] Run `/create-report "Producks"` — verify parallel agents gather from Shortcut REST API + GitHub CLI, report includes epic progress, WIP, risks, blockers
- [ ] After create-report, ask "summarize for execs" — verify `/pgm-comms executive` produces audience-appropriate output
- [ ] Run `/velocity-report` — verify it runs the full pipeline and presents the report
- [ ] Run `/investigate sc-12345` with a real story ID — verify it fetches Shortcut context before investigating
- [ ] Run `./install.sh` — verify skills list shows `pgm/comms` not just `comms`
- [ ] Verify pre-flight checkpointing: start a long conversation, run `/create-report` — should checkpoint and `/clear` if context is high

🤖 Generated with [Claude Code](https://claude.com/claude-code)