### PR TITLE
Two-layer context loading, rule extraction, and session learning

### DIFF
--- a/commands/address-feedback.md
+++ b/commands/address-feedback.md
@@ -1,7 +1,5 @@
 # /address-feedback - Address PR Review Feedback
 
-@/Users/joeli/opt/code/ai-toolkit/rules/code-review.md
-
 > **When**: A PR has review comments that need to be addressed.
 > **Produces**: Fixes committed, responses drafted or posted.
 
@@ -61,7 +59,15 @@ Triage is step 1, not the goal. The point is to fix things and respond, not to p
 
 5. **Draft Responses**
 
-   For each skipped or discussed item, draft a reply:
+   For each item, draft a reply based on verdict:
+
+   **Fixed items**: Short confirmation with commit reference.
+   ```markdown
+   ### Fixed: FB-1 (@alice — "Missing null check")
+   > Fixed in `abc1234` — added null guard for `getData()` return value.
+   ```
+
+   **Skipped / Discussed items**: Explanation with evidence.
    ```markdown
    ### Skipped: FB-2 (@bob — "Use a factory pattern")
    > Thanks for the suggestion. We're keeping the current approach since
@@ -95,6 +101,10 @@ Triage is step 1, not the goal. The point is to fix things and respond, not to p
    # Or post a general PR comment
    gh pr comment <number> --body "<response>"
    ```
+
+   **Auto-resolve bot threads**: After posting replies, resolve conversation threads from bot authors (accounts with `[bot]` suffix or `type: "Bot"` in the API response). These are mechanical checks — if the fix passes, the comment is definitively addressed.
+
+   **Leave human threads open**: Human reviewers may want to verify the fix themselves before resolving. Post the "Fixed in `<sha>`" reply but do not resolve the thread.
 
 8. **Summary**
    ```markdown

--- a/commands/cherry-pick.md
+++ b/commands/cherry-pick.md
@@ -1,9 +1,5 @@
 # /cherry-pick - Cherry-Pick One or More Changes
 
-@/Users/joeli/opt/code/ai-toolkit/rules/cherry-picking.md
-@/Users/joeli/opt/code/ai-toolkit/skills/release-engineer/SKILL.md
-@/Users/joeli/opt/code/ai-toolkit/skills/developer/SKILL.md
-
 > **When**: Moving one or more changes (bug fixes, isolated features) to another branch.
 > **Produces**: Ordered plan, clean cherry-picks with conflicts resolved where safe, and a per-change report documented in PROJECT.md.
 
@@ -92,6 +88,11 @@ If the workflow would cross a contract boundary, stop and ask the user before pr
 
    This phase owns validation depth, including stronger checks for dependency-manifest changes.
    If stronger validation would require rebuilding or refreshing the environment, stop for intervention instead of doing it automatically.
+
+   **Push after each successful cherry-pick**: After local validation passes, push immediately so CI runs against the change. CI matrices vary per repo (some include frontend, some don't) — early push gets that signal sooner rather than batching risk at the end.
+   ```bash
+   git push
+   ```
 
 6. **Document the Plan and Outcome**
 

--- a/commands/create-feature.md
+++ b/commands/create-feature.md
@@ -1,13 +1,9 @@
 # /create-feature - End-to-End Feature Workflow
 
 @/Users/joeli/opt/code/ai-toolkit/rules/planning.md
-@/Users/joeli/opt/code/ai-toolkit/rules/implementation.md
 @/Users/joeli/opt/code/ai-toolkit/rules/input-detection.md
-@/Users/joeli/opt/code/ai-toolkit/rules/testing.md
 @/Users/joeli/opt/code/ai-toolkit/rules/orchestration.md
-@/Users/joeli/opt/code/ai-toolkit/skills/pm/SKILL.md
-@/Users/joeli/opt/code/ai-toolkit/skills/developer/SKILL.md
-@/Users/joeli/opt/code/ai-toolkit/skills/qa/SKILL.md
+@/Users/joeli/opt/code/ai-toolkit/rules/complexity-gate.md
 
 > **When**: You have a feature request or other planned non-bug work and want the repo-standard workflow to scope it, review it, implement it, and keep going until a real decision matters.
 > **Produces**: Feature brief, milestones, implementation plan, reviewed plan, implemented local changes, review and QA results, and a handoff before the final commit or PR action.
@@ -56,20 +52,11 @@ Then assess complexity:
 | New APIs / migrations | No | Yes |
 | Behavioral risk | Mechanical / cosmetic | Functional change |
 
-Emit the gate block **in conversation** (not just in a plan file):
-
-```markdown
-## Complexity Gate
-Classification: TRIVIAL / STANDARD
-Confidence: X/10
-Reason: [one line]
-```
+Emit the Complexity Gate block per `rules/complexity-gate.md`.
 
 **Trivial + confidence 8/10+**: Skip to the trivial path — step 5.
 
 **Standard**: Continue to step 2. Make this decision yourself and continue automatically — do not ask the user whether to run review iterations, which reviewers to use, or whether the plan is "good enough." End-to-end commands own their internal loops.
-
-Do not silently decide — always emit the gate block above.
 
 ### 2. Plan Mode → Exploration + Design
 
@@ -144,9 +131,9 @@ If a meaningful decision surfaces during implementation, stop and present it cle
 
 Run `/review-code` on changed repo-tracked files as an internal loop. Keep iterating until only nitpicks remain or a real blocker/user decision appears.
 
-`/review-code` must emit its Review Gate block (see `review-code.md` step 3).
+The developer emits a Review Gate block per `rules/review-gate.md`. Callers branch on Status: `clean`, `blocked`, `user decision`, `skipped`.
 
-For truly minimal mechanical changes (renames, config swaps), the review loop may be skipped — but the Review Gate block must still be emitted with `Status: skipped` and a reason.
+For truly minimal mechanical changes (renames, config swaps), the review loop may be skipped per the skip rule in `rules/review-gate.md`.
 
 Do not skip this step when resuming from a pre-built plan.
 

--- a/commands/create-feature.md
+++ b/commands/create-feature.md
@@ -169,6 +169,10 @@ Lead with the outcome, not the process. If the user gave you a ticket, answer wh
 </details>
 ```
 
+### 8. Session Learning
+
+As the last step, update the `usage_patterns` memory file with the commands and skills used during this session. See "Session Learning" in `rules/universal.md`.
+
 ## Non-Negotiable Gates
 
 Use this checklist to verify you haven't skipped a gate:

--- a/commands/create-status-report.md
+++ b/commands/create-status-report.md
@@ -1,6 +1,5 @@
 # /create-status-report — Live Program Health Report
 
-@/Users/joeli/opt/code/ai-toolkit/rules/universal.md
 @/Users/joeli/opt/code/ai-toolkit/rules/pgm.md
 
 > **When**: Before meetings, weekly check-ins, or anytime you need a current snapshot of program health.

--- a/commands/create-tests.md
+++ b/commands/create-tests.md
@@ -1,7 +1,5 @@
 # /create-tests - Create the First Meaningful Tests
 
-@/Users/joeli/opt/code/ai-toolkit/rules/testing.md
-@/Users/joeli/opt/code/ai-toolkit/skills/developer/SKILL.md
 @/Users/joeli/opt/code/ai-toolkit/skills/core/review-tests/SKILL.md
 
 > **When**: You want standalone test-only work for an area that does not yet have a meaningful suite, or `/update-tests` has handed off because there is nothing real to update.

--- a/commands/create-velocity-report.md
+++ b/commands/create-velocity-report.md
@@ -1,6 +1,5 @@
 # /create-velocity-report — Monthly Velocity Metrics
 
-@/Users/joeli/opt/code/ai-toolkit/rules/universal.md
 @/Users/joeli/opt/code/ai-toolkit/rules/pgm.md
 
 > **When**: End of month (or anytime you need historical velocity metrics).

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -257,6 +257,10 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
    </details>
    ```
 
+18. **Session Learning**
+
+    As the last step, update the `usage_patterns` memory file with the commands and skills used during this session. See "Session Learning" in `rules/universal.md`.
+
 ## PROJECT.md Update Discipline
 
 Update `PROJECT.md` at these points:

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -1,11 +1,7 @@
 # /fix-bug - End-to-End Bug Workflow
 
-@/Users/joeli/opt/code/ai-toolkit/rules/investigation.md
-@/Users/joeli/opt/code/ai-toolkit/rules/implementation.md
 @/Users/joeli/opt/code/ai-toolkit/rules/input-detection.md
-@/Users/joeli/opt/code/ai-toolkit/skills/qa/SKILL.md
-@/Users/joeli/opt/code/ai-toolkit/skills/developer/SKILL.md
-@/Users/joeli/opt/code/ai-toolkit/skills/release-engineer/SKILL.md
+@/Users/joeli/opt/code/ai-toolkit/rules/complexity-gate.md
 
 > **When**: You have a bug report and want the repo-standard workflow to triage it, check whether it is already fixed upstream or pending in a PR, implement a safe fix when needed, and finish the local bug-fix flow end to end.
 > **Produces**: Triage notes, upstream-status decision, validated RCA, implemented fix when appropriate, review and QA results, and either an automatic `fix:` commit or a handoff to the user.
@@ -62,14 +58,7 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
    | Fix type | Typo, config, off-by-one | Logic, architecture |
    | Regression risk | Isolated, testable | Cross-cutting |
 
-   State the classification explicitly using the action-gate format:
-
-   ```markdown
-   ## Complexity Gate
-   Classification: TRIVIAL / STANDARD
-   Confidence: X/10
-   Reason: [one line]
-   ```
+   Emit the Complexity Gate block per `rules/complexity-gate.md`.
 
    **Trivial + confidence 8/10+**: Execute the trivial path directly — do not enter standard-path steps 3–10:
    1. Write the regression test (test-first when feasible) — even for 1-line fixes, a cheap assertion (model introspection, config check, type guard) is worth writing if it catches future drift
@@ -79,20 +68,17 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
       - **PARTIAL**: related checks ran but not the exact suite
       - **WEAK**: tests could not run locally (missing Docker, env, data) — note why
       `/review-code` inherits this assessment — do not re-discover the same limitation there.
-   4. `/review-code` — must produce Review Gate block (this is not optional)
+   4. `/review-code` — developer emits a Review Gate block per `rules/review-gate.md`
    5. Commit the fix (step 16)
    6. Update PROJECT.md (single update)
    7. Emit summary (step 17)
 
    The review gate at step 4 is mid-workflow — steps 5–7 must still execute. Do not stop after the review gate passes.
 
-   **Micro-fix** (subset of trivial): When the diff is ≤3 lines, pre-commit passes, test suite passes, and confidence is 10/10:
-   - `/review-code` may be collapsed to a single Review Gate block with `Status: micro-fix` and the diff inlined — no iterative loop needed
+   **Micro-fix** (subset of trivial): per the micro-fix rule in `rules/review-gate.md`, emit `Status: micro-fix` with the diff inlined — no iterative loop needed.
    - PROJECT.md update is optional if no PROJECT.md exists and the workflow completes in a single pass
 
    **Standard**: Continue to step 3.
-
-   Do not silently decide — always emit the gate block above.
 
 3. **Launch Early Lanes**
 
@@ -211,9 +197,9 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
 
    If step 13 or the trivial path already assessed verification strength (STRONG/PARTIAL/WEAK), pass it to `/review-code` — do not re-run the same test discovery.
 
-   `/review-code` must emit its Review Gate block (see `review-code.md` step 3).
+   The developer emits a Review Gate block per `rules/review-gate.md`. Callers branch on Status: `clean`, `blocked`, `user decision`, `skipped`, `micro-fix`.
 
-   For truly minimal mechanical fixes (typo, config value, lint-disable), the review loop may be skipped — but the Review Gate block must still be emitted with `Status: skipped` and a reason.
+   For truly minimal mechanical fixes (typo, config value, lint-disable), the review loop may be skipped per the skip rule in `rules/review-gate.md`.
 
    Do not skip this step when resuming from a pre-built plan.
 

--- a/commands/fix-ci.md
+++ b/commands/fix-ci.md
@@ -1,8 +1,6 @@
 # /fix-ci - Fix CI Failures
 
-@/Users/joeli/opt/code/ai-toolkit/rules/implementation.md
-@/Users/joeli/opt/code/ai-toolkit/skills/build-engineer/SKILL.md
-@/Users/joeli/opt/code/ai-toolkit/skills/developer/SKILL.md
+@/Users/joeli/opt/code/ai-toolkit/rules/complexity-gate.md
 
 > **When**: A CI build has failed and you want the repo-standard workflow to diagnose it, apply safe fixes, verify locally, and stop before commit.
 > **Produces**: Failure classification, PROJECT.md update, safe fixes where appropriate, validation results, and a recommended commit action.
@@ -161,15 +159,9 @@
    If repo-tracked files changed, invoke `/review-code` on the changed files as an internal loop.
    Keep iterating until only nitpicks remain or a real blocker/user decision appears.
 
-   `/review-code` must emit its Review Gate block (see `review-code.md` step 3).
+   The developer emits a Review Gate block per `rules/review-gate.md`. Callers branch on Status: `clean`, `blocked`, `user decision`, `skipped`.
 
-   **Skip rule** (aligned with trivial path sub-step 3): When the diff contains zero logic changes — formatting-only, lint-disable comments, import reordering, whitespace — skip the `/review-code` invocation and emit the Review Gate block directly:
-   ```markdown
-   ## Review Gate
-   Rounds: 0
-   Pre-flight: pass
-   Status: skipped — [reason, e.g. "formatting-only fix, no logic changes"]
-   ```
+   For zero-logic diffs (formatting-only, lint-disable, import reorder), apply the skip rule from `rules/review-gate.md`.
    If the diff touches any logic, invoke `/review-code` — do not skip.
 
 11. **Summary**

--- a/commands/review-code.md
+++ b/commands/review-code.md
@@ -1,8 +1,5 @@
 # /review-code - Wrapper Around Built-In /review
 
-@/Users/joeli/opt/code/ai-toolkit/rules/code-review.md
-@/Users/joeli/opt/code/ai-toolkit/skills/developer/SKILL.md
-
 > **When**: You have local changes (uncommitted or already committed) and want a quality pass.
 > **Produces**: Built-in `/review` findings translated into the repo-standard developer review/fix loop, with validation and a summary of changes made.
 
@@ -39,14 +36,7 @@
 
 3. **Emit the Review Gate**
 
-   This block is the required output of `/review-code`. Callers branch on it — completing the review loop without emitting this block is not sufficient.
-
-   ```markdown
-   ## Review Gate
-   Rounds: [N]
-   Pre-flight: pass / fail / skipped — [reason]
-   Status: clean / blocked / user decision
-   ```
+   The developer emits a Review Gate block per `rules/review-gate.md`. Callers branch on Status: `clean`, `blocked`, `user decision`, `skipped`, `micro-fix`.
 
 4. **Summary** (standalone runs only — skip when called from another workflow)
    ```markdown

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -1,7 +1,5 @@
 # /review-pr - Review GitHub Pull Request
 
-@/Users/joeli/opt/code/ai-toolkit/rules/code-review.md
-
 > **When**: Asked to review someone else's GitHub PR.
 > **Produces**: Scored review with actionable feedback, optionally posted to GitHub.
 

--- a/commands/run-test-plan.md
+++ b/commands/run-test-plan.md
@@ -1,8 +1,6 @@
 # /run-test-plan - Standalone QA Validation
 
-@/Users/joeli/opt/code/ai-toolkit/rules/testing.md
 @/Users/joeli/opt/code/ai-toolkit/rules/input-detection.md
-@/Users/joeli/opt/code/ai-toolkit/skills/qa/SKILL.md
 @/Users/joeli/opt/code/ai-toolkit/skills/core/review-testplan/SKILL.md
 
 > **When**: You want to validate a feature area, story, PR, or existing test-plan doc without fixing code in the same workflow.

--- a/commands/update-project-file.md
+++ b/commands/update-project-file.md
@@ -130,6 +130,10 @@ Will:
 - Write the continuation checkpoint in the standard format
 - Keep the rest of PROJECT.md untouched unless a status refresh is also needed
 
+7. **Session Learning** (optional)
+
+   When doing a checkpoint or end-of-session sync, also update the `usage_patterns` memory file with commands and skills used during the session. See "Session Learning" in `rules/universal.md`.
+
 ## Notes
 - Most commands should update PROJECT.md themselves before finishing
 - Use this command when manual cleanup or checkpoint writing is needed

--- a/commands/update-tests.md
+++ b/commands/update-tests.md
@@ -1,8 +1,5 @@
 # /update-tests - Improve an Existing Test Suite
 
-@/Users/joeli/opt/code/ai-toolkit/rules/testing.md
-@/Users/joeli/opt/code/ai-toolkit/skills/developer/SKILL.md
-@/Users/joeli/opt/code/ai-toolkit/skills/qa/SKILL.md
 @/Users/joeli/opt/code/ai-toolkit/skills/core/review-tests/SKILL.md
 
 > **When**: You want to improve an existing test suite in a specific area, path, or function and have the workflow analyze gaps, update tests, verify, review, and auto-commit when confidence is strong.

--- a/rules/complexity-gate.md
+++ b/rules/complexity-gate.md
@@ -1,0 +1,28 @@
+# Complexity Gate
+
+Classification protocol for commands that branch on trivial vs. standard paths. This defines the output block format and fast-path rule. Signal tables are command-specific and stay in commands.
+
+## Block Format
+
+Always emit this block in conversation before branching:
+
+```markdown
+## Complexity Gate
+Classification: TRIVIAL / STANDARD
+Confidence: X/10
+Reason: [one line]
+```
+
+## Trivial Fast-Path
+
+When classification is `TRIVIAL` and confidence is `8/10` or higher:
+- Skip the standard path (plan mode, investigation lanes, RCA validation)
+- Go directly to implementation, verify, review, summary
+
+## Never Silently Decide
+
+Always emit the gate block above. Do not silently choose a path — the block must be visible in conversation so the user and any continuation checkpoint can see the classification.
+
+## Scope
+
+This rule defines an output contract. It does not define the signal tables (those are command-specific) or the trivial-path steps (those are command-owned).

--- a/rules/orchestration.md
+++ b/rules/orchestration.md
@@ -35,3 +35,18 @@
 | Lose context | Update PROJECT.md |
 | Use wrong tool | Match tool to task type |
 | Retry failures blindly | Understand and simplify |
+
+## Model Selection
+
+Always use **opus** for subagents and parallel agents. When invoking the Agent tool, pass `model: "opus"`.
+
+## Subagent Context Loading
+
+Subagents load their own domain rules — commands should not `@import` rules that only subagents use.
+
+- **Main thread imports**: rules the main thread directly evaluates (complexity gate, input routing, orchestration, planning)
+- **Subagent reads**: domain rules the subagent applies (code-review, testing, implementation, investigation, review-gate, stop-rules, shortcut-api)
+- **Skill files reference rules by path**: e.g., "Read and apply `rules/review-gate.md`"
+- **Commands tell subagents which files to read**: include the rule file path in the Agent tool prompt
+
+Never load the same rule in both contexts.

--- a/rules/pgm.md
+++ b/rules/pgm.md
@@ -1,7 +1,5 @@
 # Program Management Context
 
-@/Users/joeli/opt/code/ai-toolkit/rules/shortcut-api.md
-
 ## Org Structure
 
 EM running 3 teams on kanban across 3 repos. Teams use flow-based delivery — frame everything around WIP, cycle time, throughput, and blockers. Not sprints.
@@ -32,7 +30,7 @@ Bot accounts to filter from metrics: listed in `config.json` under `bots`.
 
 ## API Reference
 
-See `rules/shortcut-api.md` for Shortcut REST patterns and `skills/shared/shortcut-fetch.md` for the retry wrapper, JSON parsing, and field shape gotchas. For PGM commands, prefer Shortcut REST API over MCP — faster, no permission prompts, richer fields.
+Subagents read `rules/shortcut-api.md` when making Shortcut API calls. See `skills/shared/shortcut-fetch.md` for the retry wrapper, JSON parsing, and field shape gotchas. For PGM commands, prefer Shortcut REST API over MCP — faster, no permission prompts, richer fields.
 
 ## Parallel Agent Pattern
 

--- a/rules/review-gate.md
+++ b/rules/review-gate.md
@@ -1,0 +1,47 @@
+# Review Gate
+
+Output contract for `/review-code` and any workflow that invokes it. This defines the block format — it does not override how review findings are produced.
+
+## Block Format
+
+Every review phase must emit this block, even when the review loop is skipped:
+
+```markdown
+## Review Gate
+Rounds: [N]
+Pre-flight: pass / fail / skipped — [reason]
+Status: clean / blocked / user decision / skipped / micro-fix
+```
+
+## Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `clean` | Only nitpicks remain; safe to proceed |
+| `blocked` | Unresolved `[major]` or `[minor]` findings; cannot proceed |
+| `user decision` | A trade-off or ambiguity requires human input |
+| `skipped` | Zero-logic diff — see skip rule below |
+| `micro-fix` | Trivial diff that passed all checks — see micro-fix rule below |
+
+## Skip Rule
+
+When the diff contains zero logic changes (formatting-only, lint-disable, import reorder, whitespace):
+- Emit the block with `Status: skipped` and a reason
+- No `/review-code` invocation needed
+- The skip applies to the review loop only — pre-flight checks still run if applicable
+
+## Micro-Fix Rule
+
+When ALL of these are true:
+- Diff is 3 lines or fewer
+- Pre-commit passes
+- Test suite passes
+- Confidence is 10/10
+
+Then:
+- `/review-code` may be collapsed to a single Review Gate block with `Status: micro-fix` and the diff inlined
+- No iterative review loop needed
+
+## Mandatory Emission
+
+The Review Gate block must appear even when the review loop is skipped. Callers branch on this block — completing a review phase without emitting it is not sufficient.

--- a/rules/shortcut-api.md
+++ b/rules/shortcut-api.md
@@ -1,9 +1,22 @@
 # Shortcut REST API
 
+## NEVER Skip the Retry
+
+The Shortcut API returns transient errors (`organization2_missing`, empty responses, 500s) on the first call of a session. This is **expected behavior**, not a real failure.
+
+**Before reporting any Shortcut API failure**:
+1. Retry the exact same request once
+2. If the retry succeeds, use the result — do not mention the first failure
+3. If the retry also fails, THEN fall back to MCP or surface the gap
+
+**NEVER**:
+- Report "API token/org issue" or "can't fetch" after a single failure
+- Switch to MCP without retrying REST first
+- Silently move on without the data after a retry failure
+- Debug or troubleshoot a single transient error
+
 **Auth**: `Shortcut-Token: $SHORTCUT_API_TOKEN` header
 **Base URL**: `https://api.app.shortcut.com/api/v3`
-
-**⚠️ Transient errors — RETRY ONCE before giving up**: The Shortcut API returns `organization2_missing` (or similar) on the first call of a session. This is normal — not a real failure. Retry the exact same request once. If the retry also fails, then fall back or surface the gap to the user. Do not report, debug, or switch to MCP on the first failure — and do not silently move on after a single retry without flagging that the data is missing.
 
 **Retry pattern** — wrap every Shortcut curl call:
 ```bash

--- a/rules/stop-rules.md
+++ b/rules/stop-rules.md
@@ -1,0 +1,19 @@
+# Stop Rules
+
+Universal stop conditions for iterative review and fix loops.
+
+## When to Stop
+
+Stop the current loop when any of these are true:
+
+- **Only nitpicks remain** — no `[major]` or `[minor]` findings left
+- **A user decision is required** — a trade-off, ambiguity, or scope question that only the user can answer
+- **Same issue persists across two consecutive rounds** — the fix attempt did not resolve it; further iteration will not help
+
+## What "Stop" Means
+
+"Stop" means surface the decision or emit the gate block — not abandon the workflow. The calling command still owns the next steps (commit, summary, handoff).
+
+## Scope
+
+This rule applies to review/fix loops (`review-local-changes.md`), plan review iterations, and any other iterative quality loop. It does not override command-specific stop conditions that are stricter.

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -10,6 +10,7 @@
 - **End-to-end commands own their internal loops** — planning, review, and validation sub-phases should continue automatically until threshold or blocker; do not surface subcommands as the next user step unless the user explicitly chose them
 - **Update PROJECT.md before completing any workflow** — every command that produces results must write current status, what was done, and remaining items to PROJECT.md before finishing
 - **Checkpoint when context is deep** — at chain boundaries and loop iterations, if context is above ~70%, save state and continue in a fresh conversation (see Context Management below)
+- **Rules evolve from usage** — when a rule is violated, strengthen it; when a rule is stale, update it; when a pattern recurs, extract it
 
 ## PROJECT.md Update Defaults
 
@@ -86,6 +87,31 @@ Auto-compaction silently drops earlier context, which can cause Claude to lose t
 - **Ask for clarification** — don't assume when unclear
 - **Request confirmation** — before destructive changes
 
+## Rule Maintenance
+
+Rules are living documents. Update them based on real-world usage:
+
+### When a rule is violated
+A rule that agents ignore is too weak. After observing a violation:
+- Strengthen the language (add NEVER lists, move critical instructions to top)
+- Add the failure pattern as a concrete example of what NOT to do
+- Consider whether the rule needs to load earlier or more prominently
+
+### When a rule is stale
+Rules drift from reality as code, APIs, and processes change. When you notice a mismatch:
+- Update the rule to match current behavior
+- Remove conditions or thresholds that no longer apply
+- Flag the update in your summary so the user knows
+
+### When a new pattern emerges
+Recurring workarounds or repeated feedback across conversations signal a missing rule. When you see a pattern:
+- Check if an existing rule covers it (update if partially covered)
+- Extract a new focused rule file if it's genuinely new
+- Keep it small — one concern per file, 20-40 lines
+
+### Scope
+Rule updates are limited to the `rules/` directory in this toolkit. Do not modify project-level CLAUDE.md files or Anthropic system behavior. Rule changes should be proposed to the user during the summary phase, not applied silently mid-workflow.
+
 ## Override Hierarchy
 
 1. **Universal principles** (this file) — always apply
@@ -110,3 +136,6 @@ Auto-compaction silently drops earlier context, which can cause Claude to lose t
 | `shortcut-api.md` | Shortcut REST API: auth, endpoints, retry, query patterns |
 | `input-detection.md` | Route ticket/issue inputs to Shortcut or GitHub |
 | `pgm.md` | Program management: org context, audience tiers, data collection rules |
+| `review-gate.md` | Review Gate output contract: block format, status values, skip/micro-fix rules |
+| `complexity-gate.md` | Complexity classification: gate block format, trivial fast-path |
+| `stop-rules.md` | Universal stop conditions for iterative loops |

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -112,6 +112,23 @@ Recurring workarounds or repeated feedback across conversations signal a missing
 ### Scope
 Rule updates are limited to the `rules/` directory in this toolkit. Do not modify project-level CLAUDE.md files or Anthropic system behavior. Rule changes should be proposed to the user during the summary phase, not applied silently mid-workflow.
 
+## Session Learning
+
+At the end of end-to-end workflows (`/fix-bug`, `/create-feature`), and optionally via `/update-project-file`, record which non-built-in commands and skills were used during the session.
+
+### What to track
+- Custom slash commands invoked (e.g., `/fix-bug`, `/create-feature`, `/review-code`, `/cherry-pick`)
+- Internal skills delegated to (e.g., `developer/investigate-bug`, `qa/triage-bug`, `core/check-existing-fix`)
+- Subagent invocations and their purposes
+
+### How to record
+Update the `usage_patterns` memory file with:
+- Date and top-level command
+- Skills and subcommands used
+- Session outcome (completed, blocked, checkpoint)
+
+Keep entries compact — one line per session, not a narrative. Over time this builds a picture of which workflows and skills get the most use, informing where to invest optimization and maintenance effort.
+
 ## Override Hierarchy
 
 1. **Universal principles** (this file) — always apply

--- a/skills/build-engineer/SKILL.md
+++ b/skills/build-engineer/SKILL.md
@@ -9,6 +9,9 @@ disable-model-invocation: true
 
 Use this persona when the task is primarily about CI, build, lint, test, dependency, or workflow failures.
 
+## Required Context
+Read before starting: `rules/implementation.md`
+
 ## Responsibilities
 
 - Own CI artifact intake and failure classification

--- a/skills/developer/SKILL.md
+++ b/skills/developer/SKILL.md
@@ -9,6 +9,9 @@ disable-model-invocation: true
 
 Use this persona when the task requires code understanding, root-cause analysis, implementation planning, code adaptation, or behavior-preserving validation.
 
+## Required Context
+Read before starting: `rules/implementation.md` (when implementing), `rules/investigation.md` (when investigating)
+
 ## Responsibilities
 
 - Investigate code paths and root causes with evidence

--- a/skills/developer/implement-change.md
+++ b/skills/developer/implement-change.md
@@ -2,6 +2,9 @@
 
 Use this phase when the workflow is ready to apply a code change after investigation and any needed planning are complete.
 
+## Required Context
+Read before starting: `rules/implementation.md`, `rules/testing.md`
+
 ## Goal
 
 Implement the narrowest fix that resolves the validated issue, add the right regression protection, and hand the result back for review and QA validation.

--- a/skills/developer/investigate-bug.md
+++ b/skills/developer/investigate-bug.md
@@ -2,6 +2,9 @@
 
 Use this phase when a workflow needs code-level RCA for a reported bug as an internal step rather than a standalone user-facing investigation command.
 
+## Required Context
+Read before starting: `rules/investigation.md`
+
 ## Goal
 
 Trace the likely failing path, identify the most plausible root cause with evidence, and hand back a compact RCA for validation.

--- a/skills/developer/review-local-changes.md
+++ b/skills/developer/review-local-changes.md
@@ -2,6 +2,9 @@
 
 Use this phase when local repo-tracked files have changed and need a review/fix loop before commit.
 
+## Required Context
+Read before starting: `rules/code-review.md`, `rules/review-gate.md`, `rules/stop-rules.md`
+
 ## Goal
 
 Wrap Claude's built-in `/review` in a repo-standard loop:
@@ -28,11 +31,7 @@ Wrap Claude's built-in `/review` in a repo-standard loop:
 
 ## Stop Rules
 
-Stop when:
-
-- only `[nitpick]` items remain
-- a user decision is required
-- the same issue persists across two consecutive rounds
+Apply stop rules from `rules/stop-rules.md`.
 
 ## Notes
 

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -9,6 +9,9 @@ disable-model-invocation: true
 
 Use this persona when the workflow needs user-visible validation, reproducible bug reports, or broader scenario thinking beyond the code change itself.
 
+## Required Context
+Read before starting: `rules/testing.md`
+
 ## Responsibilities
 
 - Confirm whether a reported issue is plausibly a bug

--- a/skills/release-engineer/SKILL.md
+++ b/skills/release-engineer/SKILL.md
@@ -9,6 +9,9 @@ disable-model-invocation: true
 
 Use this persona when the task is primarily about safely moving changes between branches, preserving git state, and minimizing unnecessary user intervention.
 
+## Required Context
+Read before starting: `rules/cherry-picking.md`
+
 ## Responsibilities
 
 - Own git state safety and branch hygiene


### PR DESCRIPTION
## Summary
- **Two-layer context loading**: Commands shed `@import` lines for rules that only subagents use; skills get `Required Context` sections pointing to domain rules they need, reducing main-thread token load
- **Rule extraction**: `review-gate.md`, `complexity-gate.md`, and `stop-rules.md` extracted as single-source-of-truth for output contracts previously duplicated across commands
- **Session learning**: Workflows record which commands/skills were used, building usage data to inform optimization
- **Misc refinements**: Shortcut API retry strengthened, address-feedback bot/human thread handling, cherry-pick push-after-each, rule maintenance protocol added to universal rules

## Test plan
- [ ] Run `/create-feature` and `/fix-bug` end-to-end — verify subagents load their own domain rules via `Required Context`
- [ ] Verify Review Gate and Complexity Gate blocks are emitted correctly from extracted rules
- [ ] Confirm commands no longer duplicate block format definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)