### PR TITLE
feat: cost-aware model tiering, cost visibility, and auto-checkpoint

### DIFF
--- a/commands/create-feature.md
+++ b/commands/create-feature.md
@@ -21,6 +21,8 @@ Plan mode is for **exploration and design only** — step 2 below. Review iterat
 4. Review iterations in normal mode (agents, auto-loop, cold read).
 5. Implement, review, summarize.
 
+**Moderate path**: Skip plan mode. Orchestrator designs inline, spawns one reviewer subagent. See step 1 for details.
+
 **Trivial path**: Skip plan mode entirely. Implement → `/review-code` → summary.
 
 ## Usage
@@ -30,8 +32,6 @@ Plan mode is for **exploration and design only** — step 2 below. Review iterat
 /create-feature apache/superset#28456
 /create-feature https://github.com/owner/repo/issues/123
 /create-feature https://app.shortcut.com/.../story/123
-/create-feature sc-epic-456                              # epic — decomposes into waves
-/create-feature https://github.com/owner/repo/milestone/5 # milestone — treated as epic
 ```
 
 ## Steps
@@ -45,34 +45,26 @@ Accept:
 
 When a ticket URL or issue reference is provided, **fetch and parse it FIRST** before any planning or code investigation. Extract scope, acceptance criteria, and constraints from the source. These are authoritative — don't re-derive scope from scratch.
 
-**Detect scope** — after fetching, determine if this is a single story or an epic:
-
-| Signal | Single story | Epic |
-|--------|-------------|------|
-| Input type | One ticket, one issue, one feature description | Shortcut epic, GitHub milestone, multiple linked stories |
-| Sub-tasks | None or implementation sub-tasks of one feature | Multiple independent features/stories |
-| Scope | One PR worth of work | Multiple PRs across different areas |
-
-**If epic → use the Epic Path section below.** Each story within the epic runs the single-story flow independently.
-
-**If single story** → continue with the complexity gate below.
-
 Then assess complexity:
 
-| Signal | Trivial | Standard |
-|--------|---------|----------|
-| Files touched | 1–2 | 3+ or unclear |
-| Design decisions | None | Any |
-| New APIs / migrations | No | Yes |
-| Behavioral risk | Mechanical / cosmetic | Functional change |
-
-Examples — TRIVIAL: add a tooltip to an existing button (1 component, no state change). STANDARD: add bulk edit for dashboard filters (new API endpoint, state management, UI components).
+| Signal | Trivial | Moderate | Standard |
+|--------|---------|----------|----------|
+| Files touched | 1–2 | 2–4, single subsystem | 3+ or unclear scope |
+| Design decisions | None | None, known pattern | Any real trade-offs |
+| New APIs / migrations | No | Minor (add endpoint, extend model) | Yes, cross-system |
+| Behavioral risk | Mechanical / cosmetic | Contained functional change | Cross-cutting functional change |
 
 Emit the Complexity Gate block per `rules/complexity-gate.md`.
 
-Record lifecycle: `gate`
-
 **Trivial + confidence 8/10+**: Skip to the trivial path — step 5.
+
+**Moderate + confidence 8/10+**: Skip plan mode and full reviewer army. Orchestrator designs inline:
+1. Explore and design in the main thread (no plan mode, no investigation subagents)
+2. Write plan to PROJECT.md (same hard gate as step 3)
+3. Spawn **one** reviewer subagent (`review-implementation`, `model: "sonnet"`) + cold read (`finalize-plan`) — 2 spawns instead of 5–6
+4. Implement, `/review-code`, summary (same as standard steps 5–7)
+
+If design reveals the feature is more complex than expected, escalate to STANDARD and enter plan mode.
 
 **Standard**: Continue to step 2. Make this decision yourself and continue automatically — do not ask the user whether to run review iterations, which reviewers to use, or whether the plan is "good enough." End-to-end commands own their internal loops.
 
@@ -80,23 +72,21 @@ Record lifecycle: `gate`
 
 Enter plan mode. Inside plan mode, do all of the following:
 
-**a. PM brief** (product criteria): Use `pm-create-feature-brief.md` to investigate the request and produce a brief with verifiable acceptance criteria. Use `pm-plan-milestones.md` for milestone framing when the work spans multiple deliverables. Skip only when the work is already tightly scoped with clear acceptance criteria — state the decision explicitly.
+**a. Decide PM scope**: Use the PM layer when scope, milestones, acceptance criteria, or rollout framing are non-trivial. Skip when the work is already tightly scoped. State the decision explicitly.
 
-**b. Architect + QA in parallel** (technical + test criteria): These are peers that both consume the PM brief — launch them together:
-- **Architect**: Use `plan-feature.md` to define the technical approach, structured slices with scope/entrance/exit criteria, and implementation sequencing.
-- **QA**: Use `qa-analyze-use-cases.md` to derive test scenarios from the PM brief's acceptance criteria, then `qa-expand-scenarios.md` to identify edge cases and adjacent flows. Produce a test plan that maps scenarios to slices.
+**b. Create the feature brief**: If PM planning is needed, use `pm-create-feature-brief.md` with milestones via `pm-plan-milestones.md`. If skipped, synthesize a minimal brief from the request.
 
-The Architect defines *how to build it*. QA defines *how to prove it works*. Neither needs the other's output — both need the PM brief. Running them in parallel means the test plan is ready before implementation starts, strengthening TDD: devs know what tests to write as part of their slice, not as an afterthought.
+**c. Create the technical plan**: Use `plan-feature.md` to define technical approach, PR slices, migrations/API implications, test strategy, and implementation sequencing.
 
-Exit plan mode when you have: feature brief, technical plan with structured slices, and QA test plan. These do not need to be polished — review iterations in step 4 will refine them.
+Exit plan mode when you have a draft feature brief and technical plan. These do not need to be polished — review iterations in step 4 will refine them.
 
 ### 3. Write PROJECT.md (hard gate)
 
 After exiting plan mode, read the plan file. Write its content into PROJECT.md sections:
-- `Feature Brief` (PM brief with acceptance criteria)
+- `Feature Brief`
 - `Milestones` (if PM planning was used)
-- `Implementation Plan` (Architect's structured slices)
-- `Test Plan` (QA's test scenarios mapped to slices)
+- `Implementation Plan`
+- `Test Strategy`
 
 **Do not proceed to step 4 until this confirmation block is emitted:**
 
@@ -111,78 +101,40 @@ This gate ensures the plan is durable before review iterations begin. If the pla
 
 Now in normal mode, iterate the plan using reviewer agents. This is the main quality gate.
 
-**a. PM brief review** (if PM planning was used): Run `review-feature-brief` and revise until 8/10.
+**a. PM brief review** (if PM planning was used): Spawn a `review-feature-brief` reviewer subagent with `model: "sonnet"` per `rules/orchestration.md` — PM briefs are scoped reviews. Use `model: "opus"` only if the brief covers multi-system rollout or material business risk. Revise until 8/10.
 
-**b. Technical plan + test plan review**: Always run these reviewers:
-- `review-architecture` — validates the Architect's slice decomposition and technical approach
-- `review-implementation` — validates feasibility, sequencing, and slice boundaries
-- `review-testplan` — validates the QA test plan covers the architecture and acceptance criteria. This reviewer now has both the technical plan and test plan, so it can verify alignment: does every slice have test coverage? Does the test plan catch cross-slice integration risks?
+**b. Technical plan review**: Always run these reviewers in parallel:
+- `review-architecture`
+- `review-implementation`
+- `review-testplan`
 
 Add when the plan needs them:
 - `review-frontend`
 - `review-backend`
 
-Revise the plan until all applicable reviewers are at 8/10 or better. Run iterations automatically — do not ask the user whether to continue or which reviewers to use. Only stop for a blocking decision that requires user input. After each round, record lifecycle: `review-round` { command: "create-feature", round: `<N>`, status: `<iterating/converged>`, finding_counts: `{major: N, minor: N}` }
+**Choose the reviewer model based on actual plan complexity**, per `rules/orchestration.md`:
+- **Trivial plan** (single subsystem, mechanical change, no architectural decisions): `model: "sonnet"`
+- **Substantial plan** (multi-system, real trade-offs, novel design, ambiguous constraints): `model: "opus"`
 
-**Convergence criteria**: Maximum 3 rounds per reviewer. If a reviewer has not reached 8/10 after 3 rounds, stop and surface the persistent issues to the user. If any reviewer is stuck below 6/10 after 2 rounds, stop immediately — further iteration is unlikely to help without user input on scope or approach.
+Revise the plan until all applicable reviewers are at 8/10 or better. Run iterations automatically — do not ask the user whether to continue or which reviewers to use. Only stop for a blocking decision that requires user input.
 
-**c. Cold read**: Use `finalize-plan` as a fresh-eyes final check. If it finds a blocking issue, revise and re-run.
+If a Sonnet reviewer scored low for *shallow analysis* (lack of depth) rather than legitimate plan issues, re-run that specific reviewer on `model: "opus"`.
+
+**c. Cold read**: Spawn `finalize-plan` as a fresh-eyes final check. Match the model to the plan's reasoning load (same rule as 4b — `model: "sonnet"` for trivial-to-moderate plans, `model: "opus"` for substantial cross-system plans). If it finds a blocking issue, revise and re-run.
 
 **d. Action gate**: Run `action-gate.md`. Auto-proceed when Risk is LOW, Confidence ≥ 8/10, and no decision is required.
 
 Update PROJECT.md with final review scores after this step.
 
-Record lifecycle: `plan-complete`
-
-### 4½. Checkpoint Before Implementation
-
-The plan→implement transition is the deepest context point in this workflow — planning rationale, review scores, and QA test plans are all in memory. Check context depth per `rules/context-management.md`. If at or above ~70%, run `/checkpoint --commit --clear` before proceeding. After `/clear`, `/start` reloads PROJECT.md (which has the full plan from step 3) and resumes at step 5.
-
 ### 5. Implementation
 
 **Standard path** (from step 4):
-
-Read the plan's structured slices from PROJECT.md. For each slice, the plan defines scope, entrance/exit criteria, and acceptance — use these to drive implementation.
-
-**5a. Dispatch implementation subagents:**
-
-The QA test plan already exists from step 2b — devs use it to know what tests to write for their slice. Each subagent gets its slice context (scope, entrance/exit criteria, acceptance) AND the relevant test scenarios from the QA test plan.
-
-Check the plan's Parallelism section and dispatch:
-- **Independent slices**: launch as parallel subagents, each with `isolation: "worktree"` and `model: "opus"`, running `implement-change.md`. The worktree isolation ensures parallel subagents don't conflict on files.
-- **Sequential slices** (depends-on chain): implement in dependency order. After each slice completes and its exit criteria are met, start the next.
-- **Single slice or no structured slices**: implement as one unit through `implement-change.md` (no worktree needed).
-
-Each subagent:
-- Verifies **entrance criteria** before starting — stops if unmet
-- Installs dependencies in the worktree if needed (`node_modules/`, build outputs)
-- Writes the failing test from the QA test plan before the code change (TDD — the test plan tells them exactly what to test)
-- Stays within the slice's **scope** boundary
-- Stops when **exit criteria** are met and **acceptance** passes
-- Commits changes on the worktree's temp branch with a message referencing the slice name
-- Returns the Implementation Handoff block
-
-**5b. Sync and merge worktrees:**
-
-Use `sync-workstreams.md` to collect subagent results, update the slice status table in PROJECT.md, and merge worktree branches. Pass the list of subagent results (Implementation Handoff blocks) and the dependency graph from the plan.
-
-The skill handles: result collection, status table updates (`queued` → `in-flight` → `complete` / `failed` / `blocked`), failure gating, dependency-ordered merges, conflict detection, and integration checks.
-
-Branch on the skill's recommendation:
-- `proceed-to-review` → continue to step 5c
-- `stop-for-failure` → surface the failure to the user before proceeding
-- `stop-for-conflict` → the plan's scope boundaries were wrong; surface for user decision
-- `stop-for-integration-failure` → merged code doesn't build; investigate before continuing
-
-Record lifecycle: `impl-complete`
-
-**5c. QA validates the integrated result:**
-
-After merge, execute the test plan from step 2b against the integrated code:
-- Run `qa-execute-use-cases.md` for the test scenarios
-- Use `qa-validate-fix.md` for scenarios that need live environment validation
-- Dev subagents already wrote unit/integration/API tests per-slice — QA execution focuses on cross-slice integration and user-facing behavior
-- In the future, QA can also own E2E test slices (Playwright tests in their own worktree) since unit/integration coverage is handled by dev subagents
+- For each implementation slice, define the acceptance or regression test first
+- Write the failing test before the code change when feasible
+- If test-first is blocked by env, repro, or harness constraints, write the test anyway and record the verification gap — writing is separate from running
+- For mechanical changes (renames, config swaps, endpoint changes with no new logic), writing tests alongside the implementation is acceptable — record why test-first was skipped
+- Implement the feature through `developer`
+- Run QA validation when the work is user-visible
 
 **Trivial path** (from step 1):
 1. Implement the change
@@ -193,19 +145,9 @@ If a meaningful decision surfaces during implementation, stop and present it cle
 
 ### 6. Review Changed Files (gate)
 
-Launch `/review-code` as a **subagent** (`model: "opus"`) with context isolation per `rules/orchestration.md`. Pass the merged diff, acceptance criteria from the PM brief, and QA test results from step 5c.
-
-For multi-slice implementations: review the full merged diff. Per-slice exit criteria already verified each slice individually — this review checks the integrated result and cross-slice interactions.
-
-**Classify review findings before looping:** Use `feedback-classify.md` to classify each finding as code-level or plan-level.
-- **Code-level**: fix in the review loop as normal
-- **Plan-level**: route back to step 4 for re-planning rather than trying to fix it in the review loop. Re-planning may invalidate implementation work, but it's cheaper than shipping a flawed design.
-
-Keep iterating until only nitpicks remain or a real blocker/user decision appears.
+Run `/review-code` on changed repo-tracked files as an internal loop. Keep iterating until only nitpicks remain or a real blocker/user decision appears.
 
 The developer emits a Review Gate block per `rules/review-gate.md`. Callers branch on Status: `clean`, `blocked`, `user decision`, `skipped`.
-
-Record lifecycle: `review-gate`
 
 For truly minimal mechanical changes (renames, config swaps), the review loop may be skipped per the skip rule in `rules/review-gate.md`.
 
@@ -243,103 +185,6 @@ Lead with the outcome, not the process. If the user gave you a ticket, answer wh
 </details>
 ```
 
-Record lifecycle: `command-complete`
-
-## Epic Path
-
-When step 1 detects an epic, use this path instead of steps 2–7. Each story runs the single-story flow independently in its own worktree.
-
-### E1. Decompose Epic
-
-Use `decompose-epic.md` to produce a wave plan — stories grouped into dependency-ordered waves. The skill analyzes what each story produces/consumes and sorts them topologically.
-
-If resuming an epic (wave plan already in PROJECT.md), skip to E3.
-
-### E2. Write Wave Plan to PROJECT.md
-
-```markdown
-## Epic: [title]
-**Reference**: [epic URL/ID]
-
-[Wave plan table from decompose-epic.md]
-
-### Wave Status
-| Wave | Stories | Status |
-|------|---------|--------|
-| 1 | [N] | pending |
-| 2 | [N] | blocked — waiting on Wave 1 |
-```
-
-### E3. Execute Current Wave
-
-Find the next wave with status `pending`. For each story in that wave, dispatch a subagent:
-
-```
-Agent(
-  isolation: "worktree",
-  model: "opus",
-  prompt: "Read and follow {{TOOLKIT_DIR}}/commands/create-feature.md for story [ref].
-    This is a single story — use the single-story path (steps 1–7).
-    You are the orchestrator for this story: create your own PROJECT.md, plan, implement, review, and commit.
-    Create branch: [branch from wave plan].
-    Return: branch name, commit SHAs, summary of what was built, and any blockers."
-)
-```
-
-Each subagent:
-- Is a **full orchestrator** for its story (nested orchestration per `rules/orchestration.md`)
-- Gets its own worktree → its own PROJECT.md, branch, and full planning/review cycle
-- Installs dependencies in the worktree per `rules/resource-management.md` (Worktree Management)
-- Runs the complete single-story flow autonomously — planning, implementation, review, commit
-- Returns results to the epic orchestrator
-
-**Concurrency**: Check resources per `rules/resource-management.md`. Typical limits: 2–3 parallel stories with Docker running, 3–4 without.
-
-After all stories in the wave complete:
-- Collect results (success/failure per story)
-- For each successful story, run `/create-pr` against the worktree branch
-- Update wave status in PROJECT.md: `pending` → `complete` or `partial (N of M)`
-- If any story failed, note it but continue with successful ones
-
-### E4. Wave Transition
-
-After creating PRs for the current wave, check if more waves remain.
-
-**If more waves AND user said "auto" or PRs are already approved**: Merge PRs via `gh pr merge --squash`, pull updated base branch, and continue to the next wave automatically. Only auto-merge if CI passes and the PR is approved — never force-merge.
-
-**Otherwise**: Report and pause for the user to merge:
-
-```markdown
-## Wave [N] Complete
-
-### PRs Created
-| Story | PR | Status |
-|-------|-----|--------|
-| [ref] | #[N] | ready for review |
-
-### Next
-Wave [N+1] has [N] stories. Merge the Wave [N] PRs, then run:
-`/create-feature [epic-ref]`
-```
-
-Update PROJECT.md wave status. The next invocation detects the wave plan, finds the next pending wave, pulls the updated base branch, and resumes from E3.
-
-If all waves are complete → emit epic summary:
-
-```markdown
-## Epic Complete — [title]
-
-### All PRs
-| Wave | Story | PR |
-|------|-------|----|
-| [N] | [ref] | #[N] |
-
-### Remaining
-- [Failed/blocked stories, or "None"]
-```
-
-Record lifecycle: `command-complete`
-
 ## Non-Negotiable Gates
 
 Use this checklist to verify you haven't skipped a gate:
@@ -351,16 +196,25 @@ Use this checklist to verify you haven't skipped a gate:
 - [ ] `/review-code` Review Gate block emitted (step 6)
 - [ ] PROJECT.md updated with final status
 - [ ] Summary emitted (step 7)
-- [ ] Lifecycle events recorded at phase boundaries
+
+## PROJECT.md Update Discipline
+
+**Standard path:**
+- **step 3** — after exiting plan mode, flush the draft plan into PROJECT.md. This is the first write and a hard gate.
+- **step 4** — after review iterations complete, update with final review scores.
+- after implementation and validation complete.
 
 ## Continuation Checkpoint
 
-**Single-story phases**: input / complexity-gate / plan-mode / project-md-write / review-iterations / action-gate / checkpoint / implement / review-code / summarize
-
-**Epic phases**: input / decompose / write-wave-plan / execute-wave / wave-transition / epic-summary
-
-State (single story):
-- Complexity: <trivial / standard>
+```markdown
+## Continuation Checkpoint — [timestamp]
+### Workflow
+- Top-level command: /create-feature <arguments>
+- Phase: input / complexity-gate / plan-mode / project-md-write / review-iterations / action-gate / implement / review-code / summarize
+- Resume target: <story, issue, milestone, PR slice, file set, or current blocker>
+- Completed items: <finished phases or accepted decisions>
+### State
+- Complexity: <trivial / moderate / standard>
 - PM required: <yes / no / skipped — trivial>
 - PM brief score: <score or skipped>
 - Technical plan scores: <reviewer: score, ... or pending>
@@ -368,20 +222,10 @@ State (single story):
 - Review status: <clean / blocked / pending>
 - Files changed so far: <files or none>
 - Pending blockers or decisions: <if any>
-
-State (epic):
-- Epic: <reference>
-- Mode: epic
-- Current wave: <N of N>
-- Wave status: <wave: status, ...>
-- Stories in current wave: <N total, N complete, N failed>
-- PRs created: <list or none>
+```
 
 ## Notes
 - `/create-feature` is the public entrypoint for planned non-bug work, including refactors where the PM layer can be skipped
-- Accepts both single stories and epics — epic detection is automatic based on input type
-- Epic path: each story runs the full single-story flow in its own worktree. The orchestrator manages wave ordering and PR creation.
-- Epic re-invocation is stateful — the wave plan in PROJECT.md persists across conversations. Run the same command after merging a wave's PRs to continue.
 - Only pause when a real decision matters
 - Use test-first implementation by default for each slice; document why when it is blocked
 - `/review-code` is an internal phase here, not the expected next top-level user step

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -8,7 +8,7 @@
 
 ## Plan Mode Usage
 
-Steps 1–2 (normalize input, complexity gate) happen **before** plan mode in normal mode. The complexity gate must be visible in conversation, and a TRIVIAL result skips plan mode entirely.
+Steps 1–2 (normalize input, complexity gate) happen **before** plan mode in normal mode. The complexity gate must be visible in conversation, and a TRIVIAL or MODERATE result skips plan mode entirely.
 
 **Standard path**: After the complexity gate, enter plan mode for investigation and planning (steps 3–10). Let plan mode's natural phases drive the work, seeded with this command's requirements:
 
@@ -21,6 +21,8 @@ Steps 1–2 (normalize input, complexity gate) happen **before** plan mode in no
 
 On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PROJECT.md, then implement, review, QA, commit.
 
+**Moderate path**: Do not enter plan mode. Orchestrator investigates and plans inline (no investigation-lane subagents). Still spawn one reviewer subagent for `/review-code`. See step 2 for details.
+
 **Trivial path**: Do not enter plan mode. Go straight to implementation.
 
 **Exit trigger**: When the action gate (step 10) says "proceed" or "plan first," exit plan mode immediately — the next steps require file writes. If it says "stop and escalate," exit plan mode and surface the decision to the user.
@@ -32,8 +34,6 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
 /fix-bug apache/superset#28456
 /fix-bug https://github.com/owner/repo/issues/123
 /fix-bug https://app.shortcut.com/.../story/123
-/fix-bug sc-123 sc-456 sc-789                           # batch — parallel worktrees
-/fix-bug "list: sc-123, apache/superset#28456, sc-789"  # batch — mixed refs
 ```
 
 ## Steps
@@ -49,26 +49,18 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
 
    Pull in external context when references are provided.
 
-   **Detect batch** — if multiple bug references are provided (multiple arguments, comma-separated list, or a ticket that links to several bugs):
-   - **Single bug** → continue to step 2 (existing flow)
-   - **Multiple bugs** → use the **Batch Path** section below
-
 2. **Complexity Gate**
 
    Assess the bug before launching investigation lanes:
 
-   | Signal | Trivial | Standard |
-   |--------|---------|----------|
-   | Root cause | Obvious from report | Needs investigation |
-   | Files touched | 1–2 | 3+ or unclear |
-   | Fix type | Typo, config, off-by-one | Logic, architecture |
-   | Regression risk | Isolated, testable | Cross-cutting |
-
-   Examples — TRIVIAL: error message has a typo (`settngs` → `settings`), one file, no logic change. STANDARD: dashboard filter applies to wrong panel — requires tracing filter propagation across 4+ files.
+   | Signal | Trivial | Moderate | Standard |
+   |--------|---------|----------|----------|
+   | Root cause | Obvious from report | Likely, needs confirmation | Needs investigation |
+   | Files touched | 1–2 | 2–4, single subsystem | 3+ or unclear scope |
+   | Fix type | Typo, config, off-by-one | Logic change, known pattern | Architecture, novel pattern |
+   | Regression risk | Isolated, testable | Contained, testable | Cross-cutting |
 
    Emit the Complexity Gate block per `rules/complexity-gate.md`.
-
-   Record lifecycle: `gate`
 
    **Trivial + confidence 8/10+**: Execute the trivial path directly — do not enter standard-path steps 3–10:
    1. Write the regression test (test-first when feasible) — even for 1-line fixes, a cheap assertion (model introspection, config check, type guard) is worth writing if it catches future drift
@@ -83,10 +75,22 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
    6. Update PROJECT.md (single update)
    7. Emit summary (step 17)
 
-   The review gate is mid-workflow — see Continuation Rule in `rules/review-gate.md`.
+   The review gate at step 4 is mid-workflow — steps 5–7 must still execute. Do not stop after the review gate passes.
 
    **Micro-fix** (subset of trivial): per the micro-fix rule in `rules/review-gate.md`, emit `Status: micro-fix` with the diff inlined — no iterative loop needed.
    - PROJECT.md update is optional if no PROJECT.md exists and the workflow completes in a single pass
+
+   **Moderate + confidence 8/10+**: Skip plan mode and investigation-lane subagents. Orchestrator works inline:
+   1. Investigate inline — read code, check existing fixes, triage in the main thread (no subagent spawns)
+   2. Write the regression test (test-first when feasible)
+   3. Implement the fix inline
+   4. Run the actual test suite covering the changed files. Record STRONG/PARTIAL/WEAK.
+   5. `/review-code` — still spawns a reviewer subagent (never review your own work)
+   6. Commit the fix (step 16)
+   7. Update PROJECT.md (single update)
+   8. Emit summary (step 17)
+
+   If investigation reveals the bug is more complex than expected (cross-system, multiple root causes), escalate to STANDARD and enter plan mode.
 
    **Standard**: Continue to step 3.
 
@@ -100,7 +104,12 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
 
    Determine whether to spin up subagents (via the Agent tool) for parallel investigation or run the lanes sequentially in the main thread. Subagents are worth it when multiple lanes involve non-trivial work (e.g., code investigation + upstream scan + environment prep). For simpler bugs, sequential in the main thread is fine.
 
-   When using subagents, pass each one the bug context (ticket summary, affected area, branch) and the relevant skill file. Collect the normalized output blocks before proceeding to step 4.
+   When using subagents, choose the model per `rules/orchestration.md`:
+   - `qa-triage-bug`, `investigate-bug`: `model: "sonnet"` — classification and bounded investigation
+   - `check-existing-fix`: `model: "sonnet"` (or `haiku` if it's pure issue-tracker search with no judgment required)
+   - `prepare-environment`: `model: "sonnet"` — mostly mechanical but may need light judgment
+
+   Pass each subagent the bug context (ticket summary, affected area, branch) and the relevant skill file. Brief them to commit to a finding rather than punt; if genuinely blocked, return `status: needs-input` with the specific question. The orchestrator surfaces blockers to the user; the subagent does not. Collect the normalized output blocks before proceeding to step 4.
 
 4. **Sync the Early Findings**
 
@@ -146,14 +155,17 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
 
    If the helper returns `FIXED_UPSTREAM`:
    - route internally to `/cherry-pick`
-   - let the cherry-pick workflow own the branch movement
+   - let `release-engineer` own the branch movement
    - return to this workflow for validation, `/review-code`, and final summary
    - do not auto-commit after the cherry-pick path; let the user decide whether any follow-up should be amended or added separately
 
 9. **Validate the RCA for Unfixed Bugs**
 
    For `UNFIXED` issues:
-   - validate the diagnosis with the shared RCA reviewer
+   - validate the diagnosis with a shared RCA reviewer subagent
+   - Model per `rules/orchestration.md`:
+     - `model: "sonnet"` when the RCA is well-bounded (single failure mode, clear evidence chain)
+     - `model: "opus"` when multiple plausible root causes exist, the failure crosses systems, or the proposed fix changes behavior in ways needing broader trade-off analysis
 
 10. **Run the Action Gate**
 
@@ -162,37 +174,18 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
    - do internal planning first
    - stop for ambiguity or risk
 
-11. **Plan Fix + QA in Parallel**
-
-   Once RCA is validated and the action gate says proceed, launch two workstreams together:
-
-   **Architect**: Use `plan-change.md` to produce structured slices with scope, entrance/exit criteria, and acceptance. The RCA tells the Architect *what* to fix; the slices define *how*.
-
-   **QA**: Use `qa-analyze-use-cases.md` to derive test scenarios from the validated RCA — what behaviors should the fix restore? What edge cases surround the root cause? Use `qa-expand-scenarios.md` to identify adjacent flows that might be affected. Produce a test plan that maps scenarios to the fix slices.
-
-   QA doesn't need the slices to plan — it needs the RCA. The Architect doesn't need the test plan to slice — it needs the RCA. Both consume the RCA, both produce criteria. Running them in parallel means devs get both the slice definitions AND the test plan before writing code.
-
-   Record lifecycle: `plan-complete`
-
-12. **Exit Plan Mode → PROJECT.md**
+11. **Exit Plan Mode → PROJECT.md**
 
    Read the plan file produced by plan mode. Write its content into PROJECT.md:
    - bug summary, repro status, affected area
    - upstream-fix status
    - validated RCA
-   - fix approach with structured slices (from Architect)
-   - QA test plan mapped to slices
+   - fix approach and test strategy
    - action-gate outcome
 
    This is the first PROJECT.md write for the standard path. All findings collected during plan mode are flushed here.
 
-12½. **Checkpoint Before Implementation**
-
-   The plan→implement transition is the deepest context point — investigation findings, RCA, QA plans, and structured slices are all in memory. Check context depth per `rules/context-management.md`. If at or above ~70%, run `/checkpoint --commit --clear` before proceeding. After `/clear`, `/start` reloads PROJECT.md (which has the full plan from step 12) and resumes at step 13.
-
-13. **Implement**
-
-   Dev subagents get both the slice context AND the QA test scenarios — they know exactly what tests to write (TDD from the QA plan).
+12. **Implement Through `developer`**
 
    Before changing the code:
    - define the regression this fix must catch
@@ -205,42 +198,44 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
    For direct fixes:
    - use `implement-change.md`
 
-   For non-trivial fixes (slices already produced in step 11):
-   - dispatch slices through `implement-change.md`:
-     - **Independent slices**: launch as parallel subagents with `isolation: "worktree"`, each verifying its own exit criteria and committing on the worktree's temp branch
-     - **Sequential slices**: implement in dependency order
-     - **Single slice**: implement as one unit (no worktree needed)
-   - after all subagents complete, use `sync-workstreams.md` to collect results, update the slice status table in PROJECT.md, and merge worktree branches. Branch on its recommendation (`proceed-to-review` / `stop-for-failure` / `stop-for-conflict`).
+   For non-trivial fixes:
+   - spawn a planning subagent (Agent tool, `subagent_type: "general-purpose"`) using `plan-change.md`. Choose the model per `rules/orchestration.md`:
+     - `model: "sonnet"` when the fix is non-mechanical but well-scoped (one module, clear constraints)
+     - `model: "opus"` when the fix spans systems, has architectural trade-offs, or the failure surface is still partially ambiguous
+   - the subagent returns the plan; the orchestrator applies it via `implement-change.md`
 
-   Record lifecycle: `impl-complete`
+13. **Expand Regression Coverage** (gate)
 
-14. **QA Validates the Fix**
+   Keep this phase tightly scoped to the bug at hand:
+   - `developer` adds or updates only the automated tests needed to protect this fix
+   - `qa` identifies must-cover scenarios, suggested follow-up tests, and out-of-scope risks
 
-   Execute the QA test plan from step 11 against the implemented code:
-   - Dev subagents already wrote unit/integration tests per-slice (from the QA test scenarios) — verify they exist and pass
-   - Run `qa-execute-use-cases.md` for cross-slice integration scenarios
-   - Use `qa-validate-fix.md` for scenarios that need live environment validation
-   - If any test is missing, add it now — do not proceed to commit without regression coverage for the root cause
+   Do not proceed to commit if no test was added or updated. If tests cannot run locally (missing Docker, env, data), write the test anyway and note the verification gap — writing the test is separate from running it. The test must exist in the commit; CI or a future local run validates it.
 
-   Do not proceed to commit if no test was added or updated. If tests cannot run locally (missing Docker, env, data), write the test anyway and note the verification gap.
+14. **Review Changed Files** (gate — not the finish line)
 
-15. **Review Changed Files** (gate)
+   Switch mental mode: review the changes as if someone else wrote them.
 
-   Launch `/review-code` as a **subagent** (`model: "opus"`) with context isolation per `rules/orchestration.md`. Pass the merged diff, validated RCA, acceptance criteria, and QA test results from step 14.
+   Run `/review-code` on changed repo-tracked files as an internal loop.
+   Keep iterating until only nitpicks remain or a real blocker/user decision appears.
 
-   For multi-slice implementations: review the full merged diff. Per-slice exit criteria already verified each slice individually — this review checks the integrated result.
+   If step 13 or the trivial path already assessed verification strength (STRONG/PARTIAL/WEAK), pass it to `/review-code` — do not re-run the same test discovery.
 
-   **Classify review findings before looping:** Use `feedback-classify.md` to classify each finding as code-level or plan-level.
-   - **Code-level** (logic, edge case, test gap): fix in the review loop as normal
-   - **Plan-level** (RCA was incomplete, slice boundary wrong, fix scope too narrow/wide): route back to step 11 for re-planning rather than looping review
+   The developer emits a Review Gate block per `rules/review-gate.md`. Callers branch on Status: `clean`, `blocked`, `user decision`, `skipped`, `micro-fix`.
 
-   If step 14 or the trivial path already assessed verification strength (STRONG/PARTIAL/WEAK), pass it to `/review-code` — do not re-run the same test discovery.
+   For truly minimal mechanical fixes (typo, config value, lint-disable), the review loop may be skipped per the skip rule in `rules/review-gate.md`.
 
-   Emit a Review Gate block per `rules/review-gate.md`. For truly minimal mechanical fixes, apply the skip rule.
+   Do not skip this step when resuming from a pre-built plan.
 
-   Record lifecycle: `review-gate`
+   **After the review gate passes, continue to steps 15–17.** The review gate is mid-workflow, not the end.
 
-   After the review gate passes, continue to steps 16–17 — see Continuation Rule in `rules/review-gate.md`.
+15. **Validate the Fix With QA When Needed**
+
+   For UI, workflow, or live-behavior bugs:
+   - run `qa-validate-fix.md` when the app is runnable locally or in a suitable environment
+   - use Playwright MCP as the default UI repro and validation path when available
+
+   If the app cannot be run locally (missing Docker, env dependencies, or data requirements), note the blocker in PROJECT.md and skip QA validation. Check prerequisites before attempting — don't discover the failure experimentally.
 
 16. **Commit New Bug Fixes**
 
@@ -251,7 +246,7 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
    - do not auto-commit beyond the cherry-pick result
    - leave any follow-up amend or extra-commit decision to the user
 
-17. **Summary** (PM wrap-up)
+17. **Summary**
 
    Lead with the answer to the user's original question — not the implementation details. If the user asked "did X break things?", answer that first. Technical details go in a collapsible section or are omitted unless the user asked for them.
 
@@ -286,110 +281,34 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
    </details>
    ```
 
-   Record lifecycle: `command-complete`
+## PROJECT.md Update Discipline
 
-## Batch Path
+Update `PROJECT.md` at these points:
 
-When step 1 detects multiple bugs, use this path instead of steps 2–17.
+**Standard path:**
+- **step 11** — after exiting plan mode, flush all investigation findings (triage, RCA, upstream status, action-gate outcome) into PROJECT.md. This is the first write.
+- after implementation, review, and QA validation
+- at final completion with the branch outcome and commit result
 
-### B1. Triage for Shared Root Causes
-
-Before dispatching, do a lightweight investigation of all bugs together:
-- Fetch each bug's description, affected area, and error details
-- Look for overlap: do multiple bugs reference the same file, component, or behavior?
-- **Shared root cause** → group them into one fix (single `/fix-bug` run, not parallel)
-- **Independent bugs** → dispatch in parallel
-
-Output:
-
-```markdown
-## Bug Batch — [N] bugs
-
-### Groups
-| Group | Bugs | Reason | Strategy |
-|-------|------|--------|----------|
-| 1 | [refs] | Shared root cause: [description] | Single fix |
-| 2 | [ref] | Independent | Parallel worktree |
-| 3 | [ref] | Independent | Parallel worktree |
-```
-
-### B2. Write Batch Plan to PROJECT.md
-
-Write the group table and tracking status:
-
-```markdown
-### Batch Status
-| # | Bug | Group | Branch | Status |
-|---|-----|-------|--------|--------|
-| 1 | [ref] | 1 | `fix/[slug]` | pending |
-| 2 | [ref] | 2 | `fix/[slug]` | pending |
-```
-
-### B3. Execute in Parallel
-
-For each independent group, dispatch a subagent:
-
-```
-Agent(
-  isolation: "worktree",
-  model: "opus",
-  prompt: "Read and follow {{TOOLKIT_DIR}}/commands/fix-bug.md for bug [ref].
-    This is a single bug — use the standard flow (steps 1–17).
-    You are the orchestrator for this bug: create your own PROJECT.md, investigate, fix, review, and commit.
-    Create branch: fix/[slug].
-    Return: branch name, commit SHAs, root cause summary, and any blockers."
-)
-```
-
-Each subagent is a **full orchestrator** for its bug (nested orchestration per `rules/orchestration.md`).
-
-For shared-root-cause groups: run as a single `/fix-bug` in one worktree with all grouped bugs as context.
-
-**Concurrency**: Check resources per `rules/resource-management.md`. Typical limits: 2–3 parallel bugs with Docker running, 3–4 without.
-
-### B4. Collect Results and Create PRs
-
-After all subagents complete:
-- Collect results (success/failure/blocked per bug)
-- Run `/create-pr` for each successful fix branch
-- Update batch status in PROJECT.md
-
-### B5. Batch Summary
-
-```markdown
-## Fix-Bug Batch Complete
-
-### Results
-| Bug | PR | Root Cause | Status |
-|-----|----|-----------|--------|
-| [ref] | #[N] | [one-line RCA] | fixed |
-| [ref] | — | [reason] | blocked |
-
-### Remaining
-- [Blocked bugs and what's needed to unblock them, or "None"]
-```
-
-Record lifecycle: `command-complete`
+Record the smallest useful status refresh each time. Do not wait until the end if the workflow has materially advanced.
 
 ## Continuation Checkpoint
 
-**Single-bug phases**: triage / complexity-gate / existing-fix-check / ui-repro / rca / action-gate / exit-plan-mode / checkpoint / implement / review / qa-validate / commit / summarize
-
-**Batch phases**: normalize / triage-shared-causes / write-batch-plan / execute-parallel / collect-results / batch-summary
-
-State (single bug):
-- Complexity: <trivial / standard>
+```markdown
+## Continuation Checkpoint — [timestamp]
+### Workflow
+- Top-level command: /fix-bug <arguments>
+- Phase: triage / complexity-gate / existing-fix-check / ui-repro / rca / action-gate / exit-plan-mode / implement / review / qa-validate / commit / summarize
+- Resume target: <issue, PR, repro path, file set, or current validation target>
+- Completed items: <finished phases or decisions already locked in>
+### State
+- Complexity: <trivial / moderate / standard>
 - Existing-fix status: <FIXED_UPSTREAM / FIX_PENDING_PR / UNFIXED>
 - RCA status: <validated / pending / not needed>
 - Review status: <clean / blocked / pending>
 - Files changed so far: <files or none>
 - Pending blockers or decisions: <if any>
-
-State (batch):
-- Mode: batch
-- Bugs: <N total, N complete, N failed, N blocked>
-- Groups: <N independent, N shared-root-cause>
-- PRs created: <list or none>
+```
 
 ## Cross-Repo Bugs
 
@@ -400,9 +319,7 @@ When the symptom is in repo A (e.g., CI failure in a downstream fork) but the fi
 - If local tests in repo B can partially cover the fix (e.g., model introspection, type checks), still run them — partial coverage beats none
 
 ## Notes
-- `/fix-bug` accepts single bugs or batches — batch detection is automatic based on input count
-- Batch path: independent bugs run in parallel worktrees, shared-root-cause bugs are grouped into one fix
-- `/fix-bug` is the public bug entrypoint; RCA-only work stays inside the internal investigation skills
+- `/fix-bug` is the public bug entrypoint; RCA-only work now stays inside the internal `developer` and `core` helpers
 - Keep `PROJECT.md` updates command-owned
 - Prefer the open-PR or cherry-pick path over inventing a new fix
 - Use test-first implementation by default; document why when the failing test cannot be written first

--- a/commands/fix-ci.md
+++ b/commands/fix-ci.md
@@ -27,46 +27,72 @@
 
 2. **Gather CI Logs**
 
-   Follow this decision tree to obtain failure logs:
+   Try `gh` first:
+   ```bash
+   # Get failed run
+   gh run list --branch <branch> --status failure --limit 1
+   gh run view <run-id> --log-failed
 
-   1. **Local file provided?** (log or zip from step 1)
-      - YES → Use it. For zips, unzip and locate failing logs; split multi-job bundles into per-failure units.
-      - NO → Continue.
+   # Or from PR
+   gh pr checks <number>
+   gh run view <run-id> --log-failed
+   ```
 
-   2. **`gh run view <run-id> --log-failed` produces output?**
-      ```bash
-      gh run list --branch <branch> --status failure --limit 1
-      gh run view <run-id> --log-failed
-      # Or from PR: gh pr checks <number> → gh run view <run-id> --log-failed
-      ```
-      - YES → Use it.
-      - NO (empty output or no failures listed) → Continue.
+   If `gh run list` returns no failures, check the check-runs endpoint — failures may be at the check-run level rather than the workflow-run level:
+   ```bash
+   gh api repos/{owner}/{repo}/commits/{sha}/check-runs \
+     --jq '.check_runs[] | select(.conclusion == "failure")'
+   ```
 
-   3. **Check-run or per-job logs available?**
-      ```bash
-      # Check-runs (failures may be at check-run level, not workflow-run level)
-      gh api repos/{owner}/{repo}/commits/{sha}/check-runs \
-        --jq '.check_runs[] | select(.conclusion == "failure")'
+   If `gh run view --log-failed` returns empty output (exit 0 but no log lines), fall back to per-job logs:
+   ```bash
+   # List jobs for the run
+   gh api repos/{owner}/{repo}/actions/runs/{run-id}/jobs \
+     --jq '.jobs[] | select(.conclusion == "failure") | {id, name}'
 
-      # Per-job logs
-      gh api repos/{owner}/{repo}/actions/runs/{run-id}/jobs \
-        --jq '.jobs[] | select(.conclusion == "failure") | {id, name}'
-      gh api repos/{owner}/{repo}/actions/jobs/{job-id}/logs
-      ```
-      - YES → Use them.
-      - NO → Continue.
+   # Fetch logs for each failed job
+   gh api repos/{owner}/{repo}/actions/jobs/{job-id}/logs
+   ```
 
-   4. **All methods failed** (or CI is external — Jenkins, GitLab, etc.)
-      - Ask the user for a log file path or URL. Do not proceed to classification without actual log output.
+   If `gh` commands fail or CI is external (Jenkins, GitLab, etc.):
+   - Check whether a local log file or zip bundle was provided in step 1.
+   - If yes, use that file as the log source.
+   - If no, ask the user for a log file path or URL. Do not proceed to classification without actual log output.
+
+   If the input is a zip bundle:
+   - unzip it automatically
+   - locate the failing logs
+   - split multi-job bundles into per-failure units before classification
 
 3. **Classify Failures**
 
-   For each failure:
-   - identify the failing step
+   The orchestrator classifies failures inline by default — no subagent needed for most CI failures. Read the gathered logs and:
+   - identify the failing step for each failure
    - match known patterns where possible
-   - produce a root-cause hypothesis
-   - produce a narrow proposed fix
+   - produce a root-cause hypothesis per failure
+   - produce a narrow proposed fix per failure
    - state local verification approach
+   - rate each failure against the complexity signals in step 4
+
+   **Spawn a triage subagent** (`model: "sonnet"`, `subagent_type: "general-purpose"`) only when:
+   - Multiple independent failures need parallel analysis
+   - Logs are very large (>500 lines) and need focused extraction
+   - The failure pattern is novel and benefits from isolated reasoning
+
+   Expected classification shape:
+   ```
+   failures:
+     - name: <failing job/step>
+       root_cause: <hypothesis>
+       fix: <narrow proposed change>
+       verification: <how to verify locally>
+       complexity: trivial | moderate | standard
+       confidence: <0-10>
+       ours: true | false  # is this caused by our diff
+   notes: <any cross-failure context>
+   ```
+
+   Commit to a classification rather than punt. If genuinely blocked (e.g., logs are missing the actual error), surface the specific question to the user.
 
 4. **Complexity Gate**
 
@@ -86,20 +112,14 @@
    ```
    If SOME failures are ours and some are pre-existing, note the pre-existing ones and continue the workflow for the remaining failures.
 
-   Evaluate each classified failure against the complexity signals, then emit the Complexity Gate block per `rules/complexity-gate.md`.
-
-   Record lifecycle: `gate`
-
    Evaluate each classified failure against:
 
-   | Signal | Trivial | Standard |
-   |--------|---------|----------|
-   | Failure pattern | Known-pattern matches (all mechanical) | Novel failure, or mixed mechanical + behavioral |
-   | Files touched | 1-2 | 3+ or unclear |
-   | Fix type | Mechanical (format, dep, config) | Logic or behavioral change |
-   | Verification | STRONG or PARTIAL available | WEAK only |
-
-   Examples — TRIVIAL: lint failure from trailing whitespace (1 file, mechanical fix). STANDARD: test fails due to race condition in async setup (requires understanding test lifecycle, 3+ files).
+   | Signal | Trivial | Moderate | Standard |
+   |--------|---------|----------|----------|
+   | Failure pattern | Known-pattern (all mechanical) | Known-pattern but behavioral | Novel or mixed |
+   | Files touched | 1–2 | 2–4, single subsystem | 3+ or unclear scope |
+   | Fix type | Mechanical (format, dep, config) | Logic change, known pattern | Behavioral, cross-cutting |
+   | Verification | STRONG or PARTIAL available | STRONG or PARTIAL available | WEAK only |
 
    **Trivial path**: all signals are in the Trivial column and confidence is 8/10 or higher. Execute the trivial path directly — do not enter standard-path steps 5–7:
    1. Apply the fix (step 8)
@@ -109,6 +129,16 @@
       - **Any other diff**: invoke `/review-code` — must produce Review Gate block.
    4. Update PROJECT.md (single update)
    5. Emit summary (step 11)
+
+   **Moderate path**: signals are in the Moderate column and confidence is 8/10 or higher. Orchestrator works inline — no planning subagent:
+   1. Plan the fix inline (orchestrator reasons about approach in conversation)
+   2. Apply the fix (step 8)
+   3. Verify locally (step 9)
+   4. `/review-code` — still spawns a reviewer subagent (never review your own work)
+   5. Update PROJECT.md (single update)
+   6. Emit summary (step 11)
+
+   If the fix turns out more complex than expected during inline planning, escalate to STANDARD.
 
    **Standard path**: any signal is in the Standard column, or confidence is below 8/10. Continue to step 5.
 
@@ -136,19 +166,30 @@
 8. **Apply Safe Fixes**
 
    If the gate allows automatic action (or the complexity gate routed here directly):
-   - apply the narrow proposed fix
-   - keep scope limited to the failing surface
-   - hand off to `implement-change.md` only when code adaptation becomes non-mechanical
+
+   - **Trivial path** (mechanical fix, high confidence): orchestrator applies the proposed fix inline. No additional subagent.
+   - **Standard path** (non-mechanical fix, multi-file, or behavioral change): spawn a planning subagent (Agent tool, `subagent_type: "general-purpose"`). Choose the model per `rules/orchestration.md` based on the actual planning load:
+     - `model: "sonnet"` when the fix is non-mechanical but well-scoped (e.g., behavioral change confined to one module, or standard-path was triggered only by weak local verification).
+     - `model: "opus"` when the fix involves real trade-offs across files/systems, or the root cause is still partially ambiguous.
+
+     Pass the subagent the classification, RCA findings, gate result, and constraint that the plan must stay scoped to the failing surface. It returns a fix plan with file-level granularity and flags any cross-cutting concerns. The **orchestrator applies the plan** — the subagent does not edit files.
+
+   Keep scope limited to the failing surface in either path.
 
    Otherwise:
    - stop
    - present the diagnosis, uncertainty, and recommended next step
 
-   **Commit strategy**: The default is to stop before commit and let the user decide. When the user requests fixes folded back into originating commits, follow the fixup+autosquash pattern in `rules/implementation.md` (Commit Strategy section).
+   **Commit strategy**: The default is to stop before commit and let the user decide. When the user requests fixes folded back into originating commits, use the fixup+autosquash pattern:
+   ```bash
+   git commit --fixup=<originating-sha>
+   # repeat for each originating commit
+   git rebase --autosquash <base>
+   ```
 
-   Record lifecycle: `impl-complete`
+   Pre-commit hook warning: when staging files for commit A's fixup, hooks stash unstaged changes (including commit B's fix) and run checks against the incomplete state. Commit fixups in dependency order — fix the earliest commit first so later commits see clean state.
 
-9. **Verify Locally**
+9. **Verify Locally** (`build-engineer`)
 
 10. **Review Changed Files** (gate)
 
@@ -159,8 +200,6 @@
 
    For zero-logic diffs (formatting-only, lint-disable, import reorder), apply the skip rule from `rules/review-gate.md`.
    If the diff touches any logic, invoke `/review-code` — do not skip.
-
-   Record lifecycle: `review-gate`
 
 11. **Summary**
    **Full template** (standard path or trivial path with PARTIAL verification):
@@ -185,19 +224,34 @@
    Next: [specific next action]
    ```
 
-   Record lifecycle: `command-complete`
+## PROJECT.md Update Discipline
+
+**Standard path** — update `PROJECT.md` at these points:
+- after log collection and initial failure classification
+- after RCA validation when that path runs
+- after the action gate determines whether the fix will proceed automatically
+- after local verification and `/review-code`
+- at final completion with verification strength and commit recommendation
+
+Keep the updates compact, but do not defer all state changes to the end of the workflow.
 
 ## Continuation Checkpoint
 
-Phases: gather-logs / classify / ownership-check / complexity-gate / rca / gate / apply / verify / review / summarize
-
-State:
-- Complexity: <trivial / standard>
+```markdown
+## Continuation Checkpoint — [timestamp]
+### Workflow
+- Top-level command: /fix-ci <arguments>
+- Phase: gather-logs / classify / ownership-check / complexity-gate / rca / gate / apply / verify / review / summarize
+- Resume target: <run id, artifact, failing job, or changed file set>
+- Completed items: <finished phases or already-fixed failures>
+### State
+- Complexity: <trivial / moderate / standard>
 - Failure summary: <current best classification>
 - Gate result: <proceed / approval / stop>
 - Review status: <clean / blocked / pending>
 - Files changed so far: <files or none>
 - Pending blockers or decisions: <if any>
+```
 
 ## Notes
 - Always read the actual failing log output — don't guess from job names alone

--- a/commands/optimize-cost.md
+++ b/commands/optimize-cost.md
@@ -1,0 +1,53 @@
+# /optimize-cost - Usage Pattern Analysis and Recommendations
+
+> **When**: You want actionable insights on how to reduce Claude Code token usage.
+> **Produces**: Analysis of usage patterns with severity-ranked findings and specific recommendations.
+
+## Usage
+```
+/optimize-cost              # Analyze last 7 days (default)
+/optimize-cost today        # Today only
+/optimize-cost 30d          # Last 30 days
+/optimize-cost month        # Current calendar month
+/optimize-cost all          # All time
+```
+
+## Steps
+
+### 1. Run the Analysis Script
+
+```bash
+python3 {{TOOLKIT_DIR}}/scripts/optimize-cost.py <period>
+```
+
+Where `<period>` is the argument from the user (default: `7d`).
+
+### 2. Present the Output
+
+The script handles all formatting. Present its output directly.
+
+### 3. Offer Context-Specific Follow-Up
+
+After presenting the analysis, offer to:
+- Apply model tiering changes to specific commands (if the model concentration finding fires)
+- Adjust checkpoint thresholds in `rules/context-management.md` (if expensive sessions are flagged)
+- Review a specific command or project that dominates cost
+
+## What It Detects
+
+| Pattern | Severity | Trigger |
+|---------|----------|---------|
+| 100% Opus usage | high | >90% cost on Opus |
+| Expensive sessions (no checkpoint) | high | Sessions exceeding $8 |
+| Long sessions (>150 messages) | medium | Quadratic cost growth |
+| Low cache hit rate | medium | <70% cache reads |
+| Command cost hotspots | medium | One command >30% of cost |
+| Project hotspots | info | One project >40% of cost |
+| High output token ratio | medium | Output >40% of cost |
+| Savings estimate | summary | Always shown |
+
+## Notes
+- This is a read-only command — it analyzes but does not modify anything
+- Costs are API-equivalent estimates for subscription users
+- Command attribution is approximate (session cost split across commands detected in that session)
+- The script parses the same JSONL files as `/show-cost`

--- a/commands/review-plan.md
+++ b/commands/review-plan.md
@@ -26,23 +26,29 @@ Read PROJECT.md. Verify it contains a plan with at least one of:
 
 If no plan content found, stop: `"No plan found in PROJECT.md. Write a plan first, then run /review-plan."`
 
-### 2. Detect Applicable Reviewers
+### 2. Assess Plan Scope and Select Reviewers
 
-**Always run:**
-- `review-architecture`
-- `review-implementation`
-- `review-testplan`
+Assess the plan's complexity to determine reviewer depth:
 
-**Conditional:**
+| Plan scope | Reviewers | Cold read |
+|------------|-----------|-----------|
+| **Moderate** — single subsystem, well-understood pattern, no architectural decisions | 1 reviewer: `review-implementation` | `finalize-plan` |
+| **Substantial** — multi-system, real trade-offs, novel design, or ambiguous constraints | 3+ reviewers: `review-architecture` + `review-implementation` + `review-testplan` | `finalize-plan` |
+
+**Conditional reviewers** (add to substantial plans when applicable):
 - `review-frontend` — if plan touches frontend (React, CSS, UI components)
 - `review-backend` — if plan touches backend (API, database, migrations)
 - `review-feature-brief` — if `--pm` flag or plan has a `Feature Brief` section with scope/milestones
 
-State which reviewers are selected and why before launching.
+State the scope assessment, which reviewers are selected, and why before launching.
 
 ### 3. Review Iterations
 
-Launch all selected reviewer subagents in parallel (`model: "opus"`). Each reviewer:
+Launch selected reviewer subagents in parallel. **Choose the reviewer model based on the actual plan complexity**, per `rules/orchestration.md`:
+- **Moderate plan**: use `model: "sonnet"`.
+- **Substantial plan** (multi-system, real trade-offs, novel design, ambiguous constraints): use `model: "opus"`.
+
+When mixed, default to Sonnet and escalate the specific failing reviewer to Opus on re-run if the Sonnet pass scored low for shallow analysis (not for legitimate plan issues). Each reviewer:
 - Reads PROJECT.md for the plan content
 - Loads its own skill file (subagents load their own domain rules)
 - Produces a scored review block (X/10 with strengths, issues, suggestions)
@@ -100,15 +106,26 @@ Write final review scores to PROJECT.md:
 - [ ] PROJECT.md updated with final scores
 - [ ] Summary emitted
 
+## PROJECT.md Update Discipline
+
+- After review iterations complete: write final scores
+- If revisions were made: the plan sections in PROJECT.md are updated as part of each revision
+
 ## Continuation Checkpoint
 
-Phases: read-plan / detect-reviewers / review-iterations / cold-read / update / summarize
-
-State:
+```markdown
+## Continuation Checkpoint — [timestamp]
+### Workflow
+- Top-level command: /review-plan [flags]
+- Phase: read-plan / detect-reviewers / review-iterations / cold-read / update / summarize
+- Resume target: [current reviewer or iteration round]
+- Completed items: [reviewers already at 8/10]
+### State
 - Reviewers selected: [list]
 - Current scores: [reviewer: score, ...]
 - Cold read: [go / no-go / pending]
 - Revisions made: [count]
+```
 
 ## Notes
 - Standalone command — `/create-feature` step 4 does the same work inline, but this is for one-off use

--- a/commands/show-cost.md
+++ b/commands/show-cost.md
@@ -1,0 +1,42 @@
+# /show-cost - Token Usage and Cost Summary
+
+> **When**: You want to understand how much you've been spending on Claude Code across projects and sessions.
+> **Produces**: Daily, weekly, and monthly cost breakdowns with model and project attribution.
+
+## Usage
+```
+/show-cost              # Last 7 days (default)
+/show-cost today        # Today only
+/show-cost 30d          # Last 30 days
+/show-cost month        # Current calendar month
+/show-cost all          # All time
+/show-cost 2026-04-01   # Since a specific date
+```
+
+## Steps
+
+### 1. Run the Aggregation Script
+
+```bash
+python3 {{TOOLKIT_DIR}}/scripts/show-cost.py <period>
+```
+
+Where `<period>` is the argument from the user (default: `7d`).
+
+### 2. Present the Output
+
+The script handles all formatting. Present its output directly — do not reformat or summarize.
+
+### 3. Interpret If Asked
+
+If the user asks "why is this expensive?", look for:
+- **High Opus output tokens**: long reasoning chains, verbose subagents
+- **Low cache hit rate**: context not being reused efficiently across turns
+- **One project dominating**: a specific workflow is burning tokens
+- **Many messages per session**: long sessions where context compresses and re-expands
+
+## Notes
+- Costs shown are **API-equivalent estimates**, not actual billing. Subscription users pay a flat rate regardless of token usage. These numbers indicate relative usage weight.
+- Session data lives in `~/.claude/projects/*/` JSONL files.
+- The script skips subagent log files (they're under `/subagents/` subdirectories).
+- Multi-day sessions are attributed proportionally to each active day.

--- a/rules/complexity-gate.md
+++ b/rules/complexity-gate.md
@@ -1,6 +1,6 @@
 # Complexity Gate
 
-Classification protocol for commands that branch on trivial vs. standard paths. This defines the output block format and fast-path rule. Signal tables are command-specific and stay in commands.
+Classification protocol for commands that branch on trivial, moderate, or standard paths. This defines the output block format and path rules. Signal tables are command-specific and stay in commands.
 
 ## Block Format
 
@@ -8,7 +8,7 @@ Always emit this block in conversation before branching:
 
 ```markdown
 ## Complexity Gate
-Classification: TRIVIAL / STANDARD
+Classification: TRIVIAL / MODERATE / STANDARD
 Confidence: X/10
 Reason: [one line]
 ```
@@ -16,8 +16,32 @@ Reason: [one line]
 ## Trivial Fast-Path
 
 When classification is `TRIVIAL` and confidence is `8/10` or higher:
-- Skip the standard path (plan mode, investigation lanes, RCA validation)
+- Skip plan mode, investigation lanes, RCA validation, and reviewer subagents
 - Go directly to implementation, verify, review, summary
+- Zero subagent spawns — orchestrator does all work inline
+
+## Moderate Path
+
+When classification is `MODERATE` and confidence is `8/10` or higher:
+- Skip plan mode and parallel investigation-lane subagents
+- Orchestrator investigates and plans inline (no investigation subagent spawns)
+- Still spawn **one** reviewer subagent for code/plan review — never review your own work
+- Still run tests and emit a Review Gate block
+- Spawn additional subagents only when parallelism provides a clear wall-clock win
+
+**When to classify MODERATE** (any of these signals):
+- 2–4 files touched, but within a single subsystem
+- Non-mechanical change, but well-understood pattern (add endpoint, extend model, new test file)
+- No architectural decisions or cross-system trade-offs
+- Clear fix or implementation approach — investigation confirms rather than discovers
+
+MODERATE is the **default classification** — most real work lands here. Use TRIVIAL only for truly mechanical changes, STANDARD only when genuine multi-system complexity or ambiguity exists.
+
+## Standard Path
+
+When classification is `STANDARD` (or confidence is below `8/10` for any classification):
+- Full workflow: plan mode, investigation lanes, reviewer subagents, RCA validation
+- Spawn subagents per command-specific steps and `rules/orchestration.md` model tiers
 
 ## Never Silently Decide
 
@@ -39,4 +63,4 @@ Always emit the gate block above. Do not silently choose a path — the block mu
 
 ## Scope
 
-This rule defines an output contract. It does not define the signal tables (those are command-specific) or the trivial-path steps (those are command-owned).
+This rule defines an output contract. It does not define the signal tables (those are command-specific) or the path-specific steps (those are command-owned).

--- a/rules/context-management.md
+++ b/rules/context-management.md
@@ -1,22 +1,33 @@
 # Context Management
 
-At every **chain boundary** or **loop iteration**, check context depth:
+At every **chain boundary** or **loop iteration**, check two things:
 
-- **Below ~70%**: Continue automatically. Don't pause.
-- **At or above ~70%**: Save state and continue in a fresh conversation. Don't ask — just do it.
+### 1. Context depth (existing rule)
+- **Below ~70%**: Continue automatically.
+- **At or above ~70%**: Finish the current action, then checkpoint.
 
+### 2. Session cost
+Read session cost from the statusline JSON (`cost.total_cost_usd`) or estimate from conversation length. Thresholds:
+
+- **Below $3** (green): Continue automatically.
+- **$3–$8** (yellow): Be aware. Consider whether the remaining work justifies continuing in this session.
+- **Above $8** (red): Finish the current action, then checkpoint. Don't ask — just do it.
+
+Cost grows quadratically in long conversations (each API call replays the full history). A fresh session with a checkpoint is cheaper than continuing a bloated one, even with the reload overhead.
+
+### Where to check
 Chain boundaries: `/fix-bug` internal phase transitions, `/create-feature` planning → implementation, `/create-feature` implementation → review, etc.
 Loop iterations: each `/create-feature` planning round, each `/review-code` round.
 Sub-invocations: when `/create-feature`, `/fix-bug`, `/update-tests`, or `/fix-ci` calls `/review-code`.
 
+**"Finish the current action"** means: complete the in-flight tool call, subagent, or review round. Don't cut off mid-edit or mid-test. But don't start the *next* phase — checkpoint first.
+
 ## Save & Continue Protocol
 
-When context is ≥ 70%, run `/checkpoint --commit --clear`. This performs the full protocol:
+When either trigger fires (context ≥ 70% OR cost > $8), run `/checkpoint`. It handles the full protocol:
 1. Writes a continuation checkpoint to PROJECT.md (see `commands/checkpoint.md` for the canonical format)
-2. Commits any uncommitted work (`--commit`)
-3. Runs `/clear` to reset conversation context (`--clear`)
-
-The `--commit --clear` flags are required for the seamless auto-flow. Without them, `/checkpoint` only writes the checkpoint to PROJECT.md (safe default for manual use).
+2. Commits any uncommitted work
+3. Runs `/clear` to reset conversation context
 
 After `/clear`, run `/start` to reload PROJECT.md and resume the saved workflow automatically.
 
@@ -25,4 +36,5 @@ The user should not need to do anything — this is a seamless context refresh.
 Do not rely on chat memory after `/clear`. The checkpoint in PROJECT.md is the source of truth for where execution resumes.
 
 ## Why This Matters
-Auto-compaction silently drops earlier context, which can cause Claude to lose track of decisions, review scores, or chain state mid-workflow. Checkpointing preserves full fidelity.
+- **Context depth**: Auto-compaction silently drops earlier context, which can cause Claude to lose track of decisions, review scores, or chain state mid-workflow.
+- **Session cost**: With a 1M context window, you can burn $50+ before hitting 70% context. Cost-based checkpointing catches the token burn that context % misses. A fresh session with a PROJECT.md checkpoint is both cheaper and higher fidelity than a long session with compacted history.

--- a/rules/orchestration.md
+++ b/rules/orchestration.md
@@ -13,11 +13,33 @@ Claude Code is the primary orchestrator: planning, investigation, complex reason
 
 ## Model Selection
 
-Each skill specifies its recommended model in its frontmatter (`model: opus`, `model: sonnet`, or `model: haiku`). When dispatching a subagent for a skill, pass the skill's model to the Agent tool.
+Match subagent model to the **actual reasoning load of this specific task**, not the category label. A "trivial architecture review" runs on Sonnet; a gnarly multi-constraint planning task runs on Opus regardless of label. The Agent tool accepts a `model` parameter — pass it explicitly on every invocation.
 
-The default is **opus** — quality matters most. Only skills doing mechanical work (pattern matching, environment checks, API wrappers) use sonnet or haiku. When unsure, use opus.
+| Reasoning load | Model | Examples |
+|----------------|-------|----------|
+| Mechanical — no judgment, just retrieval or pattern-match | `haiku` | File search, symbol grep, listing definitions, fetching a known artifact |
+| Standard — apply known patterns, classify, review bounded change, single-file work | `sonnet` | Triage, RCA validation, single-file implementation, log classification, **reviews where the diff or plan is small/well-scoped — including architecture/adversarial reviews of trivial changes** |
+| Heavy — multi-constraint trade-offs, novel design, deep adversarial probing across many files | `opus` | Plan reviews when the plan spans systems, architectural decisions with real trade-offs, adversarial review of substantial diffs, hard fix planning where the failure surface is unclear |
 
-**Dynamic override for trivial work**: When the Complexity Gate classifies work as TRIVIAL, pass `model: "sonnet"` to subagents regardless of the skill's frontmatter. Trivial changes (cosmetic fixes, renames, config swaps) don't need opus-level reasoning — sonnet handles them well at lower cost and latency. This override does not apply to the `/review-code` subagent itself (review quality should stay high even for trivial changes), only to implementation and investigation subagents.
+**The decision rule**: assess the *substance* of this specific task before choosing. Default to `sonnet`. Drop to `haiku` only for purely mechanical work. Escalate to `opus` only when this specific instance genuinely requires deep reasoning. Role labels (e.g., "architecture reviewer") do not auto-promote to Opus — the actual scope does.
+
+The orchestrator (main thread) may run on any model the user has selected — these tiers apply to **subagents** spawned from it. A Sonnet orchestrator escalating to an Opus subagent for genuinely hard work is the canonical cost-efficient pattern.
+
+## Inline-First Principle
+
+Every subagent spawn costs orchestrator messages. On subscription plans, this directly reduces how much work fits in a session. Before spawning a subagent, ask: **does this task need a separate agent, or can the orchestrator do it inline?**
+
+Spawn a subagent when:
+- Parallelism provides a clear wall-clock win (multiple independent investigation lanes)
+- Isolation matters (reviewer should not see implementation context, cold read needs fresh eyes)
+- The work is a **review** — never review your own work; always use a separate subagent for code and plan reviews
+
+Do it inline when:
+- The work is sequential anyway (classification, single-file investigation, planning a scoped fix)
+- The orchestrator already has the relevant context loaded
+- The task is bounded and the result is short (triage, RCA for a single failure mode)
+
+When the complexity gate classifies work as MODERATE, default to inline for investigation and planning, but still spawn a reviewer subagent. When STANDARD, use subagents per command-specific steps.
 
 ## Subagent Context Loading
 
@@ -29,81 +51,3 @@ Subagents load their own domain rules — commands should not `@import` rules th
 - **Commands tell subagents which files to read**: include the rule file path in the Agent tool prompt
 
 Never load the same rule in both contexts.
-
-## Skill Execution: In-Thread vs Subagent
-
-When a command says "use `skill-name.md`", it means the main thread reads the skill file and follows its instructions — same agent, same context. This is the default for sequential, single-track work.
-
-When a command says "launch as subagent" or "dispatch as parallel subagents", it means creating isolated agents via the Agent tool. Each subagent gets fresh context with only what it needs — the skill file, the relevant slice/diff, and any criteria. Subagents are used for:
-- **Parallel work**: independent slices in worktrees
-- **Isolation**: reviewers that should not see planning context (prevents confirmation bias)
-- **Domain focus**: each reviewer applies its own lens independently
-
-Pass the skill's `model` frontmatter value to the Agent tool. If the skill has no model field, default to opus.
-
-## Orchestrator Owns PROJECT.md
-
-The orchestrating agent (PM/EM role) owns all PROJECT.md writes. Subagents report results back to the orchestrator — they never write to PROJECT.md directly.
-
-**Default behavior** — update PROJECT.md at phase boundaries when the workflow has materially advanced. Don't defer everything to the end. Record the smallest useful status refresh each time: what phase completed, key findings, what's next.
-
-**Exceptions** (called out inline in the command that deviates):
-- Commands invoked as internal phases of a parent workflow (e.g., `/cherry-pick` called by `/fix-bug`) — the parent owns the update
-- Commands that may run without a PROJECT.md (e.g., `/review-pr`, `/address-feedback`) — skip if no PROJECT.md exists and the workflow completes cleanly
-- Hard gates — some commands require a PROJECT.md write before proceeding to the next phase (e.g., flushing a plan before implementation). These are marked explicitly in the command.
-
-## Continuation Checkpoints
-
-All commands use the same checkpoint structure. The canonical format is defined in `commands/checkpoint.md`:
-
-```markdown
-## Continuation Checkpoint — [timestamp]
-### Workflow
-- Top-level command: [command with arguments]
-- Phase: [current phase from command's phase list]
-- Resume target: [current item, PR, SHA, file, or blocker]
-- Completed items: [items already finished]
-### State
-[command-specific fields]
-```
-
-The `### Workflow` section is standard — commands do not restate it. Each command defines only its **phase list** and **state fields**.
-
-## Subagent Isolation
-
-When dispatching review subagents, enforce context isolation to prevent confirmation bias:
-
-- Reviewers receive **only**: the diff, changed file contents, acceptance criteria, and their skill file
-- Reviewers do **not** receive: conversation history, planning rationale, investigation context, or implementation decisions
-- **Why**: A reviewer who watched planning and implementation will rationalize issues away. Fresh context produces honest review.
-
-This applies to all `/review-code` dispatches — standalone or as an internal phase of `/fix-bug`, `/create-feature`, `/fix-ci`, etc. The calling command specifies what criteria to pass (RCA, PM brief, QA results); the isolation principle is the same.
-
-For implementation subagents dispatched in parallel:
-- Use `isolation: "worktree"` for independent slices to avoid file conflicts
-- Each subagent gets its slice context, the skill file, and exit criteria
-- After all complete, use `sync-workstreams.md` to merge results
-
-## Lifecycle Recording
-
-Event schemas are defined in `skills/workflow-lifecycle.md`. Commands record lifecycle events at phase boundaries — just specify the event type (e.g., `Record lifecycle: 'gate'`). The skill provides the field schema; do not restate it inline.
-
-**Internal phase rule**: When a command is invoked as an internal phase of a parent workflow (e.g., `/review-code` called by `/fix-bug`), skip lifecycle recording — the parent command records its own events.
-
-## Nested Orchestration
-
-Some workflows spawn subagents that are themselves orchestrators — not just workers. This happens when:
-- An epic dispatches per-story subagents, each running the full `/create-feature` flow
-- A multi-repo workflow dispatches per-repo subagents, each running end-to-end
-
-In nested orchestration:
-- The **parent orchestrator** tracks high-level progress (waves, repos) in its own PROJECT.md
-- Each **child orchestrator** (subagent in a worktree) owns its own PROJECT.md, plans, reviews, and commits independently
-- Child orchestrators do not report to the parent's PROJECT.md — the parent collects results when the subagent returns
-- The parent dispatches children with a prompt that tells them to read and follow a specific command file, not just a skill
-
-This is distinct from flat orchestration (one orchestrator, many workers) where subagents run skills and report back without owning their own planning or review cycles.
-
-## Command Composition
-
-Commands orchestrate skills as their primary workers. A small set of utility commands (`/review-code`, `/checkpoint`, `/verify`) may be invoked as internal phases by end-to-end commands. This is intentional — these commands contain adaptive logic (team selection, flag handling) that would be duplicated if extracted into skills.

--- a/scripts/optimize-cost.py
+++ b/scripts/optimize-cost.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Analyze Claude Code usage patterns and produce actionable cost optimization insights."""
+
+import json
+import os
+import sys
+import glob
+import re
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+# Same pricing as show-cost.py
+PRICING = {
+    "claude-opus-4-6": {
+        "input": 15.00, "output": 75.00,
+        "cache_read": 1.50, "cache_create": 3.75,
+    },
+    "claude-sonnet-4-6": {
+        "input": 3.00, "output": 15.00,
+        "cache_read": 0.30, "cache_create": 0.75,
+    },
+    "claude-haiku-4-5": {
+        "input": 0.80, "output": 4.00,
+        "cache_read": 0.08, "cache_create": 0.20,
+    },
+}
+DEFAULT_PRICING = PRICING["claude-opus-4-6"]
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+CYAN = "\033[36m"
+
+
+def get_pricing(model):
+    if model in PRICING:
+        return PRICING[model]
+    for key in PRICING:
+        if model.startswith(key.rsplit("-", 1)[0]):
+            return PRICING[key]
+    return DEFAULT_PRICING
+
+
+def compute_cost(usage, model):
+    p = get_pricing(model)
+    return (
+        usage.get("input_tokens", 0) * p["input"] / 1_000_000
+        + usage.get("output_tokens", 0) * p["output"] / 1_000_000
+        + usage.get("cache_read_input_tokens", 0) * p["cache_read"] / 1_000_000
+        + usage.get("cache_creation_input_tokens", 0) * p["cache_create"] / 1_000_000
+    )
+
+
+def format_cost(c):
+    if c >= 100:
+        return f"${c:,.0f}"
+    if c >= 1:
+        return f"${c:.2f}"
+    return f"${c:.3f}"
+
+
+def shorten_project(name):
+    name = name.replace("-Users-joeli-", "").replace("-Users-joeli", "~")
+    if len(name) > 40:
+        name = name[:37] + "..."
+    return name or "~"
+
+
+def extract_commands(text):
+    """Extract /command invocations from user message text."""
+    if not isinstance(text, str):
+        return []
+    return re.findall(r'/(fix-bug|fix-ci|create-feature|review-code|review-pr|review-plan|'
+                       r'create-tests|update-tests|cherry-pick|verify|start|checkpoint|'
+                       r'show-cost|optimize-cost|learn|run-test-plan|toolkit-doctor|'
+                       r'review-code-adversarial|address-feedback)', text)
+
+
+def parse_all_sessions(base_dir, since=None):
+    """Parse all sessions with detailed per-message data."""
+    sessions = []
+    for proj_dir in os.listdir(base_dir):
+        proj_path = os.path.join(base_dir, proj_dir)
+        if not os.path.isdir(proj_path):
+            continue
+        for jsonl_path in glob.glob(os.path.join(proj_path, "*.jsonl")):
+            if "/subagents/" in jsonl_path:
+                continue
+            try:
+                session = parse_session_detailed(jsonl_path, proj_dir, since)
+                if session and session["message_count"] > 0:
+                    sessions.append(session)
+            except Exception:
+                pass
+
+        # Also check for subagent costs
+        subagent_dir = os.path.join(proj_path, "subagents") if False else None
+        for jsonl_path in glob.glob(os.path.join(proj_path, "*/subagents/*.jsonl")):
+            try:
+                sa = parse_session_detailed(jsonl_path, proj_dir, since)
+                if sa and sa["message_count"] > 0:
+                    sa["is_subagent"] = True
+                    sessions.append(sa)
+            except Exception:
+                pass
+
+    return sessions
+
+
+def parse_session_detailed(path, project, since):
+    """Parse one session JSONL with per-message detail."""
+    messages = []
+    commands_used = []
+    models_used = defaultdict(lambda: {"cost": 0.0, "input": 0, "output": 0, "cache_read": 0, "count": 0})
+    total_cost = 0.0
+    total_input = 0
+    total_output = 0
+    total_cache_read = 0
+    total_cache_create = 0
+    first_ts = None
+    last_ts = None
+    session_id = None
+    message_count = 0
+
+    with open(path) as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            ts = obj.get("timestamp", "")
+            date = ts[:10] if ts else None
+            if date and since and date < since:
+                continue
+
+            if not session_id:
+                session_id = obj.get("sessionId")
+
+            # Track commands from user messages
+            if obj.get("type") == "user":
+                msg = obj.get("message", {})
+                content = msg.get("content", "") if isinstance(msg, dict) else ""
+                if isinstance(content, str):
+                    cmds = extract_commands(content)
+                    commands_used.extend(cmds)
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            cmds = extract_commands(block.get("text", ""))
+                            commands_used.extend(cmds)
+
+            # Track costs from assistant messages
+            msg = obj.get("message", {})
+            if not isinstance(msg, dict) or "usage" not in msg:
+                continue
+
+            if ts:
+                if not first_ts or ts < first_ts:
+                    first_ts = ts
+                if not last_ts or ts > last_ts:
+                    last_ts = ts
+
+            model = msg.get("model", "unknown")
+            usage = msg["usage"]
+            cost = compute_cost(usage, model)
+            inp = usage.get("input_tokens", 0)
+            out = usage.get("output_tokens", 0)
+            cr = usage.get("cache_read_input_tokens", 0)
+            cc = usage.get("cache_creation_input_tokens", 0)
+
+            total_cost += cost
+            total_input += inp
+            total_output += out
+            total_cache_read += cr
+            total_cache_create += cc
+            message_count += 1
+
+            models_used[model]["cost"] += cost
+            models_used[model]["input"] += inp + cr + cc
+            models_used[model]["output"] += out
+            models_used[model]["cache_read"] += cr
+            models_used[model]["count"] += 1
+
+    if message_count == 0:
+        return None
+
+    total_all_input = total_input + total_cache_read + total_cache_create
+    cache_rate = (total_cache_read / total_all_input * 100) if total_all_input > 0 else 0
+
+    # Estimate duration
+    duration_min = 0
+    if first_ts and last_ts:
+        try:
+            t1 = datetime.fromisoformat(first_ts.replace("Z", "+00:00"))
+            t2 = datetime.fromisoformat(last_ts.replace("Z", "+00:00"))
+            duration_min = (t2 - t1).total_seconds() / 60
+        except Exception:
+            pass
+
+    return {
+        "session_id": session_id,
+        "project": project,
+        "path": path,
+        "first_ts": first_ts,
+        "last_ts": last_ts,
+        "date": (first_ts[:10] if first_ts else "unknown"),
+        "total_cost": total_cost,
+        "total_input": total_all_input,
+        "total_output": total_output,
+        "cache_read": total_cache_read,
+        "cache_rate": cache_rate,
+        "message_count": message_count,
+        "duration_min": duration_min,
+        "models": dict(models_used),
+        "commands": commands_used,
+        "is_subagent": False,
+    }
+
+
+def analyze(sessions):
+    """Run all analysis passes and return findings."""
+    findings = []
+
+    if not sessions:
+        return ["No session data found."]
+
+    main_sessions = [s for s in sessions if not s.get("is_subagent")]
+    total_cost = sum(s["total_cost"] for s in main_sessions)
+    total_messages = sum(s["message_count"] for s in main_sessions)
+
+    # 1. Model concentration
+    model_costs = defaultdict(float)
+    for s in main_sessions:
+        for model, data in s["models"].items():
+            model_costs[model] += data["cost"]
+
+    opus_cost = sum(v for k, v in model_costs.items() if "opus" in k)
+    opus_pct = (opus_cost / total_cost * 100) if total_cost > 0 else 0
+    if opus_pct > 90:
+        sonnet_equiv = opus_cost * 0.2  # Sonnet is ~1/5 the cost
+        savings = opus_cost - sonnet_equiv
+        findings.append({
+            "severity": "high",
+            "title": "100% Opus usage — no model tiering",
+            "detail": (f"All {format_cost(total_cost)} is on Opus. If 60% of subagent work "
+                       f"moved to Sonnet, estimated savings: ~{format_cost(savings * 0.6)}/period."),
+            "action": "Apply model tiering per rules/orchestration.md — Sonnet for triage/review, Opus for hard planning only.",
+        })
+
+    # 2. Expensive sessions (cost > $8 without checkpoint)
+    expensive = [s for s in main_sessions if s["total_cost"] > 8]
+    if expensive:
+        avg_expensive = sum(s["total_cost"] for s in expensive) / len(expensive)
+        total_expensive = sum(s["total_cost"] for s in expensive)
+        pct_of_total = (total_expensive / total_cost * 100) if total_cost > 0 else 0
+        findings.append({
+            "severity": "high",
+            "title": f"{len(expensive)} sessions exceeded $8 checkpoint threshold",
+            "detail": (f"These {len(expensive)} sessions account for {format_cost(total_expensive)} "
+                       f"({pct_of_total:.0f}% of total). Average: {format_cost(avg_expensive)}/session. "
+                       f"Top offender: {format_cost(max(s['total_cost'] for s in expensive))}."),
+            "action": "Auto-checkpoint at $8 per context-management.md. Each continuation saves ~30-50% vs continuing in a bloated session.",
+        })
+
+    # 3. Long sessions (>150 messages)
+    long_sessions = [s for s in main_sessions if s["message_count"] > 150]
+    if long_sessions:
+        avg_msgs = sum(s["message_count"] for s in long_sessions) / len(long_sessions)
+        findings.append({
+            "severity": "medium",
+            "title": f"{len(long_sessions)} sessions with >150 messages",
+            "detail": (f"Average {avg_msgs:.0f} messages. Long sessions pay quadratic cost — "
+                       f"each API call replays the full history."),
+            "action": "Checkpoint earlier. Cost-based trigger ($8) catches this automatically.",
+        })
+
+    # 4. Cache efficiency
+    overall_cache_read = sum(s["cache_read"] for s in main_sessions)
+    overall_input = sum(s["total_input"] for s in main_sessions)
+    overall_cache_rate = (overall_cache_read / overall_input * 100) if overall_input > 0 else 0
+
+    low_cache = [s for s in main_sessions if s["cache_rate"] < 70 and s["message_count"] > 10]
+    if low_cache:
+        findings.append({
+            "severity": "medium",
+            "title": f"{len(low_cache)} sessions with <70% cache hit rate",
+            "detail": (f"Overall cache rate: {overall_cache_rate:.0f}%. "
+                       f"Low-cache sessions waste tokens re-sending context that could be cached."),
+            "action": "Short sessions or sessions with rapidly changing context have lower cache rates. "
+                      "This is partly structural — checkpointing more frequently can help.",
+        })
+    elif overall_cache_rate > 85:
+        findings.append({
+            "severity": "good",
+            "title": f"Cache hit rate is strong at {overall_cache_rate:.0f}%",
+            "detail": "Most input tokens are served from cache, which is 10x cheaper than fresh input.",
+            "action": "No action needed. Keep sessions focused to maintain this.",
+        })
+
+    # 5. Command cost attribution
+    cmd_costs = defaultdict(lambda: {"cost": 0.0, "count": 0, "sessions": 0})
+    for s in main_sessions:
+        seen_cmds = set(s["commands"])
+        for cmd in seen_cmds:
+            cmd_costs[cmd]["sessions"] += 1
+        # Attribute session cost proportionally to commands used
+        n_cmds = len(seen_cmds) or 1
+        for cmd in seen_cmds:
+            cmd_costs[cmd]["cost"] += s["total_cost"] / n_cmds
+        for cmd in s["commands"]:
+            cmd_costs[cmd]["count"] += 1
+
+    if cmd_costs:
+        sorted_cmds = sorted(cmd_costs.items(), key=lambda x: x[1]["cost"], reverse=True)
+        top_cmd = sorted_cmds[0]
+        if top_cmd[1]["cost"] > total_cost * 0.3:
+            findings.append({
+                "severity": "medium",
+                "title": f"/{top_cmd[0]} accounts for ~{format_cost(top_cmd[1]['cost'])} ({top_cmd[1]['cost']/total_cost*100:.0f}%)",
+                "detail": (f"Used {top_cmd[1]['count']} times across {top_cmd[1]['sessions']} sessions. "
+                           f"This is the biggest optimization target."),
+                "action": f"Review /{top_cmd[0]} for model tiering and checkpoint opportunities.",
+            })
+
+    # 6. Project hotspots
+    proj_costs = defaultdict(lambda: {"cost": 0.0, "sessions": 0})
+    for s in main_sessions:
+        proj = shorten_project(s["project"])
+        proj_costs[proj]["cost"] += s["total_cost"]
+        proj_costs[proj]["sessions"] += 1
+
+    sorted_projs = sorted(proj_costs.items(), key=lambda x: x[1]["cost"], reverse=True)
+    if sorted_projs and sorted_projs[0][1]["cost"] > total_cost * 0.4:
+        top_proj = sorted_projs[0]
+        findings.append({
+            "severity": "info",
+            "title": f"Project '{top_proj[0]}' accounts for {top_proj[1]['cost']/total_cost*100:.0f}% of cost",
+            "detail": f"{format_cost(top_proj[1]['cost'])} across {top_proj[1]['sessions']} sessions.",
+            "action": "Focus model tiering and checkpoint discipline on this project first for maximum impact.",
+        })
+
+    # 7. Output token ratio
+    total_output_tokens = sum(s["total_output"] for s in main_sessions)
+    output_cost = total_output_tokens * 75.0 / 1_000_000  # Opus output pricing
+    output_pct = (output_cost / total_cost * 100) if total_cost > 0 else 0
+    if output_pct > 40:
+        findings.append({
+            "severity": "medium",
+            "title": f"Output tokens account for {output_pct:.0f}% of cost",
+            "detail": (f"Opus output is $75/MTok (5x input). {total_output_tokens/1_000_000:.1f}M output tokens "
+                       f"= {format_cost(output_cost)}."),
+            "action": "Verbose subagent responses and long explanations drive output cost. "
+                      "Instruct subagents to return structured data, not prose.",
+        })
+
+    # 8. Potential savings summary
+    if total_cost > 0:
+        # Estimate savings from model tiering (60% of work to Sonnet = 80% cheaper on that portion)
+        tiering_savings = total_cost * 0.6 * 0.8
+        # Estimate savings from checkpointing (expensive sessions could save 30%)
+        checkpoint_savings = sum(s["total_cost"] * 0.3 for s in expensive) if expensive else 0
+        total_savings = tiering_savings + checkpoint_savings
+
+        findings.append({
+            "severity": "summary",
+            "title": "Estimated savings potential",
+            "detail": (f"Model tiering: ~{format_cost(tiering_savings)} "
+                       f"({tiering_savings/total_cost*100:.0f}% reduction)\n"
+                       f"             Cost-based checkpointing: ~{format_cost(checkpoint_savings)}\n"
+                       f"             Combined: ~{format_cost(total_savings)} "
+                       f"({total_savings/total_cost*100:.0f}% reduction)"),
+            "action": "",
+        })
+
+    return findings
+
+
+def print_findings(findings):
+    """Pretty-print analysis findings."""
+    severity_icons = {
+        "high": f"{RED}!!{RESET}",
+        "medium": f"{YELLOW} !{RESET}",
+        "good": f"{GREEN} +{RESET}",
+        "info": f"{CYAN} i{RESET}",
+        "summary": f"{BOLD}=={RESET}",
+    }
+
+    print(f"\n{BOLD}{'=' * 60}{RESET}")
+    print(f"{BOLD}Cost Optimization Analysis{RESET}")
+    print(f"{'=' * 60}\n")
+
+    for f in findings:
+        icon = severity_icons.get(f["severity"], "  ")
+        print(f"  {icon} {BOLD}{f['title']}{RESET}")
+        for line in f["detail"].split("\n"):
+            print(f"     {line}")
+        if f["action"]:
+            print(f"     {DIM}Action: {f['action']}{RESET}")
+        print()
+
+
+def main():
+    period = "7d"
+    if len(sys.argv) > 1:
+        period = sys.argv[1]
+
+    base_dir = os.path.expanduser("~/.claude/projects")
+    if not os.path.isdir(base_dir):
+        print("No Claude Code session data found.")
+        sys.exit(1)
+
+    today = datetime.now().date()
+    if period == "today":
+        since = today.isoformat()
+    elif period.endswith("d"):
+        days = int(period[:-1])
+        since = (today - timedelta(days=days)).isoformat()
+    elif period == "month":
+        since = today.replace(day=1).isoformat()
+    elif period == "all":
+        since = None
+    else:
+        since = period
+
+    print(f"{DIM}Analyzing usage patterns...{RESET}")
+    sessions = parse_all_sessions(base_dir, since)
+    findings = analyze(sessions)
+    print_findings(findings)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/show-cost.py
+++ b/scripts/show-cost.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Aggregate Claude Code token usage and estimated costs from session JSONL files."""
+
+import json
+import os
+import sys
+import glob
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+# Per-model pricing ($/MTok) — API-equivalent costs for subscription users
+PRICING = {
+    "claude-opus-4-6": {
+        "input": 15.00, "output": 75.00,
+        "cache_read": 1.50, "cache_create": 3.75,
+    },
+    "claude-sonnet-4-6": {
+        "input": 3.00, "output": 15.00,
+        "cache_read": 0.30, "cache_create": 0.75,
+    },
+    "claude-haiku-4-5": {
+        "input": 0.80, "output": 4.00,
+        "cache_read": 0.08, "cache_create": 0.20,
+    },
+}
+
+# Fallback for unknown models — use Opus pricing as worst-case
+DEFAULT_PRICING = PRICING["claude-opus-4-6"]
+
+# ANSI colors
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+CYAN = "\033[36m"
+
+
+def get_pricing(model):
+    """Get pricing for a model, matching by prefix for version variants."""
+    if model in PRICING:
+        return PRICING[model]
+    for key in PRICING:
+        if model.startswith(key.rsplit("-", 1)[0]):
+            return PRICING[key]
+    return DEFAULT_PRICING
+
+
+def compute_cost(usage, model):
+    """Compute cost in USD for a single usage record."""
+    p = get_pricing(model)
+    inp = usage.get("input_tokens", 0)
+    out = usage.get("output_tokens", 0)
+    cache_read = usage.get("cache_read_input_tokens", 0)
+    cache_create = usage.get("cache_creation_input_tokens", 0)
+    return (
+        inp * p["input"] / 1_000_000
+        + out * p["output"] / 1_000_000
+        + cache_read * p["cache_read"] / 1_000_000
+        + cache_create * p["cache_create"] / 1_000_000
+    )
+
+
+def parse_sessions(base_dir, since=None):
+    """Parse all session JSONL files, return per-session aggregated data."""
+    sessions = []
+    for proj_dir in os.listdir(base_dir):
+        proj_path = os.path.join(base_dir, proj_dir)
+        if not os.path.isdir(proj_path):
+            continue
+        for jsonl_path in glob.glob(os.path.join(proj_path, "*.jsonl")):
+            # Skip subagent logs
+            if "/subagents/" in jsonl_path:
+                continue
+            try:
+                session = parse_one_session(jsonl_path, proj_dir, since)
+                if session and session["messages"] > 0:
+                    sessions.append(session)
+            except Exception:
+                pass
+    return sessions
+
+
+def parse_one_session(path, project, since):
+    """Parse a single session JSONL file."""
+    totals = defaultdict(lambda: {
+        "input": 0, "output": 0, "cache_read": 0, "cache_create": 0,
+        "cost": 0.0, "messages": 0,
+    })
+    dates = set()
+    first_ts = None
+    last_ts = None
+    session_id = None
+    message_count = 0
+
+    with open(path) as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            ts_str = obj.get("timestamp", "")
+            if not session_id:
+                session_id = obj.get("sessionId")
+
+            msg = obj.get("message", {})
+            if not isinstance(msg, dict) or "usage" not in msg:
+                continue
+
+            # Parse timestamp
+            date = ts_str[:10] if ts_str else None
+            if date and since and date < since:
+                continue
+
+            if date:
+                dates.add(date)
+            if ts_str:
+                if not first_ts or ts_str < first_ts:
+                    first_ts = ts_str
+                if not last_ts or ts_str > last_ts:
+                    last_ts = ts_str
+
+            model = msg.get("model", "unknown")
+            usage = msg["usage"]
+            inp = usage.get("input_tokens", 0)
+            out = usage.get("output_tokens", 0)
+            cr = usage.get("cache_read_input_tokens", 0)
+            cc = usage.get("cache_creation_input_tokens", 0)
+            cost = compute_cost(usage, model)
+
+            totals[model]["input"] += inp
+            totals[model]["output"] += out
+            totals[model]["cache_read"] += cr
+            totals[model]["cache_create"] += cc
+            totals[model]["cost"] += cost
+            totals[model]["messages"] += 1
+            message_count += 1
+
+    if message_count == 0:
+        return None
+
+    total_cost = sum(t["cost"] for t in totals.values())
+    total_input = sum(t["input"] + t["cache_read"] + t["cache_create"] for t in totals.values())
+    total_output = sum(t["output"] for t in totals.values())
+    cache_read_total = sum(t["cache_read"] for t in totals.values())
+    cache_create_total = sum(t["cache_create"] for t in totals.values())
+
+    return {
+        "session_id": session_id,
+        "project": project,
+        "path": path,
+        "first_ts": first_ts,
+        "last_ts": last_ts,
+        "dates": sorted(dates),
+        "models": dict(totals),
+        "total_cost": total_cost,
+        "total_input": total_input,
+        "total_output": total_output,
+        "cache_read": cache_read_total,
+        "cache_create": cache_create_total,
+        "messages": message_count,
+    }
+
+
+def format_tokens(n):
+    """Format token count with K/M suffix."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.0f}K"
+    return str(n)
+
+
+def format_cost(c):
+    """Format cost in dollars."""
+    if c >= 100:
+        return f"${c:,.0f}"
+    if c >= 1:
+        return f"${c:.2f}"
+    return f"${c:.3f}"
+
+
+def shorten_project(name):
+    """Shorten project dir name for display."""
+    # Remove the leading -Users-joeli- prefix
+    name = name.replace("-Users-joeli-", "").replace("-Users-joeli", "~")
+    # Collapse common path separators
+    name = name.replace("--", "/").replace("-", "/", 2) if name.startswith("opt") else name
+    if len(name) > 35:
+        name = name[:32] + "..."
+    return name or "~"
+
+
+def aggregate_by_date(sessions):
+    """Roll up sessions into per-date aggregates."""
+    by_date = defaultdict(lambda: {
+        "cost": 0.0, "input": 0, "output": 0,
+        "cache_read": 0, "messages": 0, "sessions": 0,
+        "models": defaultdict(lambda: {"cost": 0.0, "messages": 0}),
+        "projects": defaultdict(lambda: {"cost": 0.0, "messages": 0}),
+    })
+    for s in sessions:
+        for date in s["dates"]:
+            # Approximate: attribute full session to each active date equally
+            n_dates = len(s["dates"]) or 1
+            frac = 1.0 / n_dates
+            d = by_date[date]
+            d["cost"] += s["total_cost"] * frac
+            d["input"] += int(s["total_input"] * frac)
+            d["output"] += int(s["total_output"] * frac)
+            d["cache_read"] += int(s["cache_read"] * frac)
+            d["messages"] += int(s["messages"] * frac)
+            d["sessions"] += 1
+            for model, mdata in s["models"].items():
+                d["models"][model]["cost"] += mdata["cost"] * frac
+                d["models"][model]["messages"] += int(mdata["messages"] * frac)
+            proj = shorten_project(s["project"])
+            d["projects"][proj]["cost"] += s["total_cost"] * frac
+            d["projects"][proj]["messages"] += int(s["messages"] * frac)
+    return by_date
+
+
+def print_period(label, dates_data, show_details=True):
+    """Print a period summary."""
+    total_cost = sum(d["cost"] for d in dates_data.values())
+    total_msgs = sum(d["messages"] for d in dates_data.values())
+    total_input = sum(d["input"] for d in dates_data.values())
+    total_output = sum(d["output"] for d in dates_data.values())
+    total_cache = sum(d["cache_read"] for d in dates_data.values())
+
+    cache_pct = (total_cache / total_input * 100) if total_input > 0 else 0
+
+    print(f"\n{BOLD}{'=' * 60}{RESET}")
+    print(f"{BOLD}{label}{RESET}")
+    print(f"{'=' * 60}")
+    print(f"  Cost: {CYAN}{format_cost(total_cost)}{RESET}  |  "
+          f"Messages: {total_msgs:,}  |  "
+          f"In: {format_tokens(total_input)}  Out: {format_tokens(total_output)}")
+    print(f"  Cache hit rate: {GREEN}{cache_pct:.0f}%{RESET}")
+
+    if not show_details:
+        return
+
+    # Daily breakdown
+    print(f"\n  {BOLD}Daily{RESET}")
+    print(f"  {'Date':<12} {'Cost':>8} {'Msgs':>6} {'Input':>8} {'Output':>8}")
+    print(f"  {'-' * 46}")
+    for date in sorted(dates_data.keys()):
+        d = dates_data[date]
+        cost_color = RED if d["cost"] > 5 else YELLOW if d["cost"] > 2 else ""
+        print(f"  {date:<12} {cost_color}{format_cost(d['cost']):>8}{RESET} "
+              f"{d['messages']:>6} {format_tokens(d['input']):>8} {format_tokens(d['output']):>8}")
+
+    # Model breakdown
+    model_totals = defaultdict(lambda: {"cost": 0.0, "messages": 0})
+    for d in dates_data.values():
+        for model, mdata in d["models"].items():
+            model_totals[model]["cost"] += mdata["cost"]
+            model_totals[model]["messages"] += mdata["messages"]
+
+    if model_totals:
+        print(f"\n  {BOLD}By Model{RESET}")
+        print(f"  {'Model':<25} {'Cost':>8} {'Msgs':>6} {'% Cost':>8}")
+        print(f"  {'-' * 50}")
+        for model in sorted(model_totals, key=lambda m: model_totals[m]["cost"], reverse=True):
+            mt = model_totals[model]
+            pct = (mt["cost"] / total_cost * 100) if total_cost > 0 else 0
+            print(f"  {model:<25} {format_cost(mt['cost']):>8} {mt['messages']:>6} {pct:>7.0f}%")
+
+    # Project breakdown (top 5)
+    proj_totals = defaultdict(lambda: {"cost": 0.0, "messages": 0})
+    for d in dates_data.values():
+        for proj, pdata in d["projects"].items():
+            proj_totals[proj]["cost"] += pdata["cost"]
+            proj_totals[proj]["messages"] += pdata["messages"]
+
+    if proj_totals:
+        print(f"\n  {BOLD}By Project (top 5){RESET}")
+        print(f"  {'Project':<35} {'Cost':>8} {'Msgs':>6}")
+        print(f"  {'-' * 52}")
+        sorted_projs = sorted(proj_totals, key=lambda p: proj_totals[p]["cost"], reverse=True)[:5]
+        for proj in sorted_projs:
+            pt = proj_totals[proj]
+            print(f"  {proj:<35} {format_cost(pt['cost']):>8} {pt['messages']:>6}")
+
+
+def main():
+    period = "7d"
+    if len(sys.argv) > 1:
+        period = sys.argv[1]
+
+    base_dir = os.path.expanduser("~/.claude/projects")
+    if not os.path.isdir(base_dir):
+        print("No Claude Code session data found at ~/.claude/projects/")
+        sys.exit(1)
+
+    # Compute date ranges
+    today = datetime.now().date()
+    if period == "today":
+        since = today.isoformat()
+    elif period.endswith("d"):
+        days = int(period[:-1])
+        since = (today - timedelta(days=days)).isoformat()
+    elif period == "month":
+        since = today.replace(day=1).isoformat()
+    elif period == "all":
+        since = None
+    else:
+        # Try as YYYY-MM-DD
+        since = period
+
+    print(f"{DIM}Scanning session files...{RESET}")
+    sessions = parse_sessions(base_dir, since)
+
+    if not sessions:
+        print(f"No session data found for period: {period}")
+        sys.exit(0)
+
+    by_date = aggregate_by_date(sessions)
+
+    # Determine period boundaries
+    all_dates = sorted(by_date.keys())
+    first = all_dates[0] if all_dates else "?"
+    last = all_dates[-1] if all_dates else "?"
+
+    print_period(
+        f"Usage: {first} to {last}  ({len(sessions)} sessions, {len(all_dates)} days)",
+        by_date,
+        show_details=True,
+    )
+
+    # Weekly rollup if more than 7 days
+    if len(all_dates) > 7:
+        print(f"\n{BOLD}Weekly Totals{RESET}")
+        print(f"  {'Week':<20} {'Cost':>8} {'Msgs':>6}")
+        print(f"  {'-' * 36}")
+        week_data = defaultdict(lambda: {"cost": 0.0, "messages": 0})
+        for date, d in by_date.items():
+            dt = datetime.strptime(date, "%Y-%m-%d").date()
+            week_start = (dt - timedelta(days=dt.weekday())).isoformat()
+            week_data[week_start]["cost"] += d["cost"]
+            week_data[week_start]["messages"] += d["messages"]
+        for week in sorted(week_data.keys()):
+            w = week_data[week]
+            print(f"  {week:<20} {format_cost(w['cost']):>8} {w['messages']:>6}")
+
+    print(f"\n{DIM}Note: Costs are API-equivalent estimates, not actual billing.{RESET}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/statusline/statusline-command.sh
+++ b/statusline/statusline-command.sh
@@ -3,60 +3,180 @@
 # Read JSON input from stdin
 input=$(cat)
 
-# Model name: strip leading "Claude " and keep sentence case, e.g. "Claude Opus 4.6" -> "Opus 4.6"
-model_raw=$(echo "$input" | jq -r '.model.display_name // empty')
-model_name=$(echo "$model_raw" | sed 's/^[Cc]laude //')
-
-# Get current directory (last component only)
-cwd=$(echo "$input" | jq -r '.workspace.current_dir')
-short_dir=$(basename "$cwd")
-
-# Get git branch
-branch_str=""
-if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
-    branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
-    if [ -n "$branch" ]; then
-        branch_str="Branch: $branch"
-    fi
-fi
-
-# Color-coded context used percentage
-# Green: used < 50% (remaining > 50%), Yellow: used >= 50% (remaining <= 50%), Red: used >= 70% (remaining <= 30%)
+# Colors
 RESET="\033[0m"
 GREEN="\033[32m"
 YELLOW="\033[33m"
 RED="\033[31m"
+DIM="\033[2m"
 
-context_str=""
+# --- Helpers ---
+
+# make_bar <percentage 0-100> <width> → "████░░░░"
+make_bar() {
+    local pct=$1
+    local width=${2:-8}
+    # clamp
+    (( pct < 0 )) && pct=0
+    (( pct > 100 )) && pct=100
+    local filled=$(( pct * width / 100 ))
+    local empty=$(( width - filled ))
+    local bar=""
+    for ((i=0; i<filled; i++)); do bar+="█"; done
+    for ((i=0; i<empty; i++)); do bar+="░"; done
+    echo "$bar"
+}
+
+# color_for_pct <percentage> <yellow_threshold> <red_threshold>
+color_for_pct() {
+    local pct=$1 yellow=$2 red=$3
+    if [ "$pct" -ge "$red" ]; then
+        echo "$RED"
+    elif [ "$pct" -ge "$yellow" ]; then
+        echo "$YELLOW"
+    else
+        echo "$GREEN"
+    fi
+}
+
+# --- Data extraction ---
+
+# Model name: strip leading "Claude "
+model_raw=$(echo "$input" | jq -r '.model.display_name // empty')
+model_name=$(echo "$model_raw" | sed 's/^[Cc]laude //')
+
+# Effort level
+effort_str=""
+settings_file="$HOME/.claude/settings.json"
+if [ -f "$settings_file" ]; then
+    effort=$(jq -r '.effortLevel // empty' "$settings_file" 2>/dev/null)
+    if [ -n "$effort" ]; then
+        case "$effort" in
+            max)  effort_str=$(printf "${RED}%s${RESET}" "$effort") ;;
+            high) effort_str=$(printf "${YELLOW}%s${RESET}" "$effort") ;;
+            *)    effort_str=$(printf "${DIM}%s${RESET}" "$effort") ;;
+        esac
+    fi
+fi
+
+# Message count
+msg_str=""
+transcript=$(echo "$input" | jq -r '.transcript_path // empty')
+if [ -n "$transcript" ] && [ -f "$transcript" ]; then
+    msg_count=$(wc -l < "$transcript" 2>/dev/null | tr -d ' ')
+    if [ -n "$msg_count" ] && [ "$msg_count" -gt 0 ]; then
+        if [ "$msg_count" -ge 100 ]; then
+            msg_color="$RED"
+        elif [ "$msg_count" -ge 50 ]; then
+            msg_color="$YELLOW"
+        else
+            msg_color="$GREEN"
+        fi
+        msg_str=$(printf "${msg_color}%d msgs${RESET}" "$msg_count")
+    fi
+fi
+
+# Session cost
+cost_str=""
+cost_usd=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
+if [ -n "$cost_usd" ]; then
+    cost_cents=$(printf "%.0f" "$(echo "$cost_usd * 100" | bc 2>/dev/null || echo 0)")
+    if [ "$cost_cents" -ge 800 ]; then
+        cost_color="$RED"
+    elif [ "$cost_cents" -ge 300 ]; then
+        cost_color="$YELLOW"
+    else
+        cost_color="$GREEN"
+    fi
+    cost_str=$(printf "${cost_color}\$%.2f${RESET}" "$cost_usd")
+fi
+
+# Git branch
+cwd=$(echo "$input" | jq -r '.workspace.current_dir')
+branch=""
+if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
+    branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
+fi
+
+# Repo name
+short_dir=$(basename "$cwd")
+
+# Context used percentage
+ctx_pct=""
 remaining=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')
 if [ -n "$remaining" ]; then
     remaining_int=$(printf "%.0f" "$remaining")
-    used_int=$((100 - remaining_int))
-    if [ "$used_int" -ge 70 ]; then
-        color="$RED"
-    elif [ "$used_int" -ge 50 ]; then
-        color="$YELLOW"
-    else
-        color="$GREEN"
-    fi
-    context_str=$(printf "${color}Context: %d%%${RESET}" "$used_int")
+    ctx_pct=$((100 - remaining_int))
 fi
 
-# Output format: "Model | Context: XX% | Branch: <branch> | Directory: <dir>"
-parts=()
-[ -n "$model_name" ] && parts+=("$model_name")
-[ -n "$context_str" ] && parts+=("$context_str")
-[ -n "$branch_str" ] && parts+=("$branch_str")
-parts+=("Directory: $short_dir")
+# Rate limits
+five_hr_pct=""
+five_hr=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+if [ -n "$five_hr" ]; then
+    five_hr_pct=$(printf "%.0f" "$five_hr")
+fi
 
-# Join parts with " | "
-result=""
-for part in "${parts[@]}"; do
-    if [ -z "$result" ]; then
-        result="$part"
+seven_day_pct=""
+seven_day=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+if [ -n "$seven_day" ]; then
+    seven_day_pct=$(printf "%.0f" "$seven_day")
+fi
+
+# --- Line 1: model effort | msgs | $cost | branch | repo ---
+line1_parts=()
+if [ -n "$model_name" ] && [ -n "$effort_str" ]; then
+    line1_parts+=("$(printf "%s %s" "$model_name" "$effort_str")")
+elif [ -n "$model_name" ]; then
+    line1_parts+=("$model_name")
+fi
+[ -n "$msg_str" ] && line1_parts+=("$msg_str")
+[ -n "$cost_str" ] && line1_parts+=("$cost_str")
+[ -n "$branch" ] && line1_parts+=("$branch")
+line1_parts+=("$short_dir")
+
+line1=""
+for part in "${line1_parts[@]}"; do
+    if [ -z "$line1" ]; then
+        line1="$part"
     else
-        result="${result} | ${part}"
+        line1="${line1} | ${part}"
     fi
 done
 
-printf "%s" "$result"
+# --- Line 2: resource bars — Ctx, 5h, 7d ---
+BAR_WIDTH=8
+line2_parts=()
+
+if [ -n "$ctx_pct" ]; then
+    bar=$(make_bar "$ctx_pct" "$BAR_WIDTH")
+    color=$(color_for_pct "$ctx_pct" 50 70)
+    line2_parts+=("$(printf "Context ${color}%s${RESET}" "$bar")")
+fi
+
+if [ -n "$five_hr_pct" ]; then
+    bar=$(make_bar "$five_hr_pct" "$BAR_WIDTH")
+    color=$(color_for_pct "$five_hr_pct" 50 80)
+    line2_parts+=("$(printf "5h ${color}%s${RESET}" "$bar")")
+fi
+
+if [ -n "$seven_day_pct" ]; then
+    bar=$(make_bar "$seven_day_pct" "$BAR_WIDTH")
+    color=$(color_for_pct "$seven_day_pct" 50 80)
+    line2_parts+=("$(printf "7d ${color}%s${RESET}" "$bar")")
+fi
+
+line2=""
+for part in "${line2_parts[@]}"; do
+    if [ -z "$line2" ]; then
+        line2="$part"
+    else
+        line2="${line2} | ${part}"
+    fi
+done
+
+# Output both lines
+if [ -n "$line2" ]; then
+    printf "%s\n%s" "$line1" "$line2"
+else
+    printf "%s" "$line1"
+fi


### PR DESCRIPTION
## Summary
- **Model tiering for subagents**: Match model to reasoning load (haiku/sonnet/opus) instead of defaulting to Opus. Applied across `/create-feature`, `/fix-bug`, `/fix-ci`, `/review-plan`, and `orchestration.md`.
- **Cost visibility commands**: `/show-cost` and `/optimize-cost` with Python scripts that parse session JSONL for token usage, model attribution, and savings opportunities.
- **Cost-based auto-checkpoint**: `context-management.md` now triggers checkpoint at $8 session cost in addition to 70% context depth.
- **Statusline v2**: Two-line display with progress bars for context/rate limits, message count, effort level, and cost.
- **Complexity gate updates**: Reviewer model selection based on actual plan complexity.

## Test plan
- [ ] Verify `/show-cost` and `/optimize-cost` parse transcripts correctly
- [ ] Confirm reviewer subagents in `/create-feature` respect model tiering
- [ ] Check statusline renders two lines with progress bars
- [ ] Validate cost thresholds in context-management trigger checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)