### PR TITLE
feat: auto-proceed on trivial fast-path across all end-to-end commands

### DIFF
--- a/commands/create-feature.md
+++ b/commands/create-feature.md
@@ -56,7 +56,7 @@ Then assess complexity:
 
 Emit the Complexity Gate block per `rules/complexity-gate.md`.
 
-**Trivial + confidence 8/10+**: Skip to the trivial path — step 5.
+**Trivial + confidence 8/10+**: Auto-proceed — do not ask the user for confirmation; skip to the trivial path — step 5.
 
 **Moderate + confidence 8/10+**: Skip plan mode and full reviewer army. Orchestrator designs inline:
 1. Explore and design in the main thread (no plan mode, no investigation subagents)

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -62,7 +62,7 @@ On exit, plan mode produces a plan file. Step 11 reads it: flush findings to PRO
 
    Emit the Complexity Gate block per `rules/complexity-gate.md`.
 
-   **Trivial + confidence 8/10+**: Execute the trivial path directly — do not enter standard-path steps 3–10:
+   **Trivial + confidence 8/10+**: Auto-proceed — do not ask the user for confirmation; execute the trivial path directly without entering standard-path steps 3–10:
    1. Write the regression test (test-first when feasible) — even for 1-line fixes, a cheap assertion (model introspection, config check, type guard) is worth writing if it catches future drift
    2. Implement the fix — do not enter plan mode for trivial fixes; go straight to the edit
    3. Run the actual test suite covering the changed files (e.g., `pytest -k ...`, `jest --testPathPattern ...`) — pre-commit alone is not sufficient. Record the result:

--- a/commands/fix-ci.md
+++ b/commands/fix-ci.md
@@ -121,7 +121,7 @@
    | Fix type | Mechanical (format, dep, config) | Logic change, known pattern | Behavioral, cross-cutting |
    | Verification | STRONG or PARTIAL available | STRONG or PARTIAL available | WEAK only |
 
-   **Trivial path**: all signals are in the Trivial column and confidence is 8/10 or higher. Execute the trivial path directly — do not enter standard-path steps 5–7:
+   **Trivial path**: all signals are in the Trivial column and confidence is 8/10 or higher. Auto-proceed — do not ask the user for confirmation; execute the trivial path directly without entering standard-path steps 5–7:
    1. Apply the fix (step 8)
    2. Verify locally (step 9)
    3. Review gate — choose based on diff content:

--- a/rules/complexity-gate.md
+++ b/rules/complexity-gate.md
@@ -16,6 +16,7 @@ Reason: [one line]
 ## Trivial Fast-Path
 
 When classification is `TRIVIAL` and confidence is `8/10` or higher:
+- **Auto-proceed** — do not ask the user for confirmation before implementing; the high-confidence classification is the approval
 - Skip plan mode, investigation lanes, RCA validation, and reviewer subagents
 - Go directly to implementation, verify, review, summary
 - Zero subagent spawns — orchestrator does all work inline


### PR DESCRIPTION
## Summary
- Trivial + high-confidence (8/10+) fixes in `fix-ci` and `create-feature` were still pausing for user confirmation, inconsistent with `fix-bug`
- Added explicit "auto-proceed — do not ask the user for confirmation" language to all three commands and the canonical `complexity-gate` rule

## Changes
- **`rules/complexity-gate.md`** — added auto-proceed bullet to the Trivial Fast-Path section (canonical rule)
- **`commands/fix-bug.md`**, **`commands/fix-ci.md`**, **`commands/create-feature.md`** — aligned trivial-path wording to match: auto-proceed without confirmation

## Test plan
- [ ] Run `/fix-bug` on a trivial issue — should not prompt for confirmation
- [ ] Run `/fix-ci` on a trivial CI failure — should not prompt for confirmation
- [ ] Run `/create-feature` on a trivial feature — should not prompt for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)