### PR TITLE
fix(statusline): use zone-based color for progress bars

### DIFF
--- a/commands/cherry-pick.md
+++ b/commands/cherry-pick.md
@@ -82,7 +82,7 @@ If the workflow would cross a contract boundary, stop and ask the user before pr
    Reason: [one line]
    ```
 
-   - **Mechanical + confidence 8/10+**: fast path — apply directly, validate with targeted checks, skip full adapt cycle. If a single change and `Risk: LOW`, combine investigate and apply into one phase.
+   - **Mechanical + confidence 8/10+**: fast path — apply directly, skip full adapt cycle. **Still runs diff audit via validate subagent** — clean applies are the primary scope leak vector. If a single change and `Risk: LOW`, combine investigate and apply into one phase.
    - **Non-mechanical**: full path — investigate, adapt if needed, validate, and stop for user decisions when required.
 
    Auto-proceed only when the helper rates the change low-risk, high-confidence, and not decision-bound.
@@ -103,12 +103,23 @@ If the workflow would cross a contract boundary, stop and ask the user before pr
    If the cherry-pick state is lost, do not continue blindly; return to the apply phase.
    If a prerequisite or behavior decision is required, stop and ask the user.
 
-5. **Validate Each Applied Change**
+5. **Validate Each Applied Change (subagent — mandatory)**
 
-   This phase owns validation depth, including stronger checks for dependency-manifest changes.
+   **Always run validation as a subagent**, never inline in the orchestrator thread. The thread that applied the cherry-pick must not validate its own work — the same separation principle as code review. Use `model: "sonnet"` per `rules/orchestration.md`.
+
+   **The diff audit is mandatory for every cherry-pick, including clean applies.** Clean applies are the highest-risk vector for scope leak — when git resolves without conflicts, nobody scrutinizes the result, and changes from adjacent commits on the source branch silently enter the target. The #38809 incident (SC-104110, P1) was a clean cherry-pick that leaked the `hideTab` guard from an adjacent commit.
+
+   The subagent runs `cherry-pick-validate.md` which includes:
+   1. **Diff audit** — compare source commit diff vs cherry-pick result diff, flag extra files/hunks
+   2. **Build/lint/type-check** — repo-standard checks
+   3. **Targeted tests** — covering the changed area
+
+   If the diff audit finds scope leak, the subagent reverts the leaked hunks and reports back. The orchestrator then amends the cherry-pick before pushing.
+
+   This phase also owns validation depth for dependency-manifest changes.
    If stronger validation would require rebuilding or refreshing the environment, stop for intervention instead of doing it automatically.
 
-   **Push after each successful cherry-pick**: After local validation passes, push immediately so CI runs against the change. CI matrices vary per repo (some include frontend, some don't) — early push gets that signal sooner rather than batching risk at the end.
+   **Push after each successful cherry-pick**: After local validation passes, push immediately so CI runs against the change.
    ```bash
    git push
    ```

--- a/rules/cherry-picking.md
+++ b/rules/cherry-picking.md
@@ -10,6 +10,7 @@
 - [ ] **Adapt rather than force** — work with target architecture
 - [ ] **Verify imports/modules exist** in target branch
 - [ ] **Prefer functional over structural** — extract value, not architecture
+- [ ] **Audit cherry-pick scope** — after resolution, diff-audit the result against the source commit to detect leaked changes from adjacent commits (see validate phase)
 - [ ] **Document decisions** — what accepted, rejected, why
 
 ## Accept vs Reject

--- a/skills/cherry-pick-adapt.md
+++ b/skills/cherry-pick-adapt.md
@@ -51,6 +51,20 @@ When a bug-fix cherry-pick is rejected or has significant portions dropped due t
 2. If yes, surface it as a residual risk item in the Detailed Notes — not buried in adaptation notes, but called out as an actionable item (e.g., "the encoding bug likely affects the target branch via `ExecuteSqlCore` — needs a separate fix").
 3. The cherry-picking rules say "validate bug exists in target branch." That validation doesn't end when the fix is rejected — the bug's existence is still the user's problem.
 
+## Scope Leak Detection
+
+Conflict resolution is the primary vector for **scope leak** — where changes from adjacent commits on the source branch silently enter the cherry-pick through a resolved hunk.
+
+This happens when the source branch's version of a conflicting region includes changes from commits *other than* the one being cherry-picked. Accepting the source side wholesale (or resolving toward it) brings in those unrelated changes.
+
+After resolving each conflicting file:
+
+1. Get the source commit's original diff for that file: `git diff <commit>^..<commit> -- <file>`
+2. Compare against your resolution: any lines in the resolved version that aren't in the source commit's diff and weren't already on the target branch are leak candidates.
+3. If leak is detected, strip the unrelated lines and keep only the cherry-picked commit's changes adapted to the target branch's context.
+
+When in doubt about whether a line belongs to the cherry-picked commit or leaked from an adjacent one, check `git log --oneline <source-commit>..HEAD -- <file>` on the source branch to identify which commit introduced it.
+
 ## Escalation Triggers
 
 Stop and ask for user input when:
@@ -59,3 +73,4 @@ Stop and ask for user input when:
 - the adaptation changes externally visible behavior
 - the target branch lacks required architectural groundwork
 - dropping a bug fix leaves the underlying bug unaddressed on the target branch (surface the residual risk even if proceeding)
+- scope leak detection finds changes from adjacent commits that may be intentional prerequisites

--- a/skills/cherry-pick-validate.md
+++ b/skills/cherry-pick-validate.md
@@ -23,6 +23,28 @@ When project tooling allows it safely, run these in parallel:
 
 Avoid parallel validation when the project's test/build tooling fights for the same generated outputs or shared local environment.
 
+## Diff Audit (Scope Leak Check)
+
+Run this **before** build/test validation. A clean build doesn't catch unrelated changes that happen to compile.
+
+1. Get the source commit's diff: `git diff <source-commit>^..<source-commit>`
+2. Get the cherry-pick result diff: `git diff HEAD^..HEAD`
+3. Compare file-by-file:
+   - **Extra files**: any file changed in the cherry-pick that wasn't in the source commit is a leak. Revert it with `git checkout HEAD^ -- <file>` and amend.
+   - **Extra hunks**: within a shared file, any hunk in the cherry-pick diff that has no corresponding change in the source diff is a leak candidate. It may be a legitimate adaptation (e.g., import path change for the target branch) or an accidental pickup from an adjacent commit.
+4. For each extra hunk, determine origin: `git log --oneline --all -S "<leaked line>" -- <file>` — if it belongs to a different commit than the one being cherry-picked, it's a leak.
+5. Report findings as a **Scope Audit** block:
+
+```markdown
+## Scope Audit
+Files in source: [N] | Files in cherry-pick: [M]
+Extra files: [list or "none"]
+Extra hunks: [list with origin commit or "none"]
+Verdict: [clean / leaked — reverted / leaked — kept with justification]
+```
+
+If the audit finds leaks, revert them before proceeding to build/test validation. If a leaked change appears to be a required prerequisite, escalate to the user rather than silently keeping it.
+
 ## Validation Order
 
 At minimum:

--- a/skills/cherry-pick-validate.md
+++ b/skills/cherry-pick-validate.md
@@ -6,9 +6,11 @@ model: sonnet
 
 Use this phase after a cherry-pick applies cleanly or after conflict resolution completes.
 
+**This phase must always run as a subagent**, never inline in the orchestrator thread. The thread that applied the cherry-pick must not validate its own work.
+
 ## Goal
 
-Prove that the moved change is integrated cleanly and did not leave the target branch in a broken state.
+Prove that the moved change is integrated cleanly, contains only the intended changes, and did not leave the target branch in a broken state.
 
 This phase owns post-apply verification only.
 It should consume risk signals from investigate and adaptation signals from adapt rather than re-litigating whether the cherry-pick should have happened.
@@ -23,9 +25,11 @@ When project tooling allows it safely, run these in parallel:
 
 Avoid parallel validation when the project's test/build tooling fights for the same generated outputs or shared local environment.
 
-## Diff Audit (Scope Leak Check)
+## Diff Audit (Scope Leak Check) — MANDATORY
 
 Run this **before** build/test validation. A clean build doesn't catch unrelated changes that happen to compile.
+
+**This step is mandatory for every cherry-pick, including clean applies with zero conflicts.** Clean applies are the highest-risk vector for scope leak — git silently picks up the source branch's current state of conflicting regions, which may include changes from adjacent commits that happened to touch the same lines. No conflicts are raised, no scrutiny is triggered, and the leaked code ships.
 
 1. Get the source commit's diff: `git diff <source-commit>^..<source-commit>`
 2. Get the cherry-pick result diff: `git diff HEAD^..HEAD`

--- a/statusline/statusline-command.sh
+++ b/statusline/statusline-command.sh
@@ -18,7 +18,7 @@ FG_RED="\033[31m"
 # --- Helpers ---
 
 # make_gradient_bar <percentage> <yellow_threshold> <red_threshold> [inner_width=10]
-# Renders: [  XX%  ] — filled cells use green/yellow/red gradient based on position
+# Renders: [  XX%  ] — filled cells use zone color based on current percentage
 make_gradient_bar() {
     local pct=$1
     local yellow=$2
@@ -27,8 +27,15 @@ make_gradient_bar() {
     (( pct < 0 )) && pct=0
     (( pct > 100 )) && pct=100
     local filled=$(( pct * width / 100 ))
-    local yellow_col=$(( yellow * width / 100 ))
-    local red_col=$(( red * width / 100 ))
+    # Zone color: determined by where pct falls, not cell position
+    local zone_fg
+    if [ "$pct" -ge "$red" ]; then
+        zone_fg="$FG_RED"
+    elif [ "$pct" -ge "$yellow" ]; then
+        zone_fg="$FG_YELLOW"
+    else
+        zone_fg="$FG_GREEN"
+    fi
     local text
     text=$(printf "%d%%" "$pct")
     local tlen=${#text}
@@ -40,16 +47,8 @@ make_gradient_bar() {
     for ((i=0; i<width; i++)); do
         local ch="${full_inner:$i:1}"
         if [ "$i" -lt "$filled" ]; then
-            local fg
-            if [ "$i" -ge "$red_col" ]; then
-                fg="$FG_RED"
-            elif [ "$i" -ge "$yellow_col" ]; then
-                fg="$FG_YELLOW"
-            else
-                fg="$FG_GREEN"
-            fi
             if [ "$ch" = " " ]; then
-                bar+=$(printf "%b%b▒%b" "$BG_CHECK" "$fg" "$RESET")
+                bar+=$(printf "%b%b▒%b" "$BG_CHECK" "$zone_fg" "$RESET")
             else
                 bar+=$(printf "%b%b%s%b" "$BG_CHECK" "$WHITE" "$ch" "$RESET")
             fi


### PR DESCRIPTION
## What changed

Progress bar cells were colored by their **position** in the bar (a positional gradient), not by where the current percentage falls. At 70% with a 50% yellow threshold, this produced 5 green cells + 2 yellow cells — visually dominated by green even though the metric is clearly in the yellow zone.

Now all filled `▒` cells use the **zone color** of the current percentage:
- `pct < yellow_threshold` → green
- `yellow_threshold ≤ pct < red_threshold` → yellow
- `pct ≥ red_threshold` → red

## Why

The old behavior was misleading. A bar at 70% (past the warning threshold) looked green at a glance. The new behavior gives an unambiguous at-a-glance signal.

## Details

- Digit characters (e.g. `70%`) inside the filled region stay **white** for readability — the color signal comes from the `▒` block characters only
- Unfilled cells and their overlapping text characters remain dim gray, unchanged
- All three bars (session/ctx, 5h rate limit, 7d rate limit) benefit from this fix