### PR TITLE
refactor(cherry-pick): redesign flow with gate, plan-review cycle, and scope leak detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ai-toolkit/
 │   ├── check-existing-fix.md   # Upstream fix check
 │   ├── action-gate.md       # Shared proceed/stop decision helper
 │   ├── shortcut-fetch.md    # Shortcut API retry wrapper
-│   ├── cherry-pick-*.md     # Cherry-pick phases (adapt, apply, investigate, plan, validate)
+│   ├── cherry-pick-*.md     # Cherry-pick phases (investigate, gate, plan, apply, adapt, validate, batch-sequence)
 │   ├── ci-*.md              # CI/build tasks (classify-failure, verify-fix)
 │   ├── pm-*.md              # Product management (create-feature-brief, plan-milestones)
 │   ├── qa-*.md              # QA tasks (analyze-use-cases, capture-evidence, execute/expand, file-bug, report-shortcut-results, triage-bug, validate-fix)

--- a/commands/cherry-pick.md
+++ b/commands/cherry-pick.md
@@ -9,7 +9,10 @@
 Safely move one or more isolated changes onto the target branch.
 
 ### In Scope
-- reorder requested cherries when needed
+- reorder requested cherries when needed (batch only)
+- gate each change: should we cherry at all?
+- plan each cherry-pick's application strategy
+- review each plan before applying
 - auto-apply low-risk changes
 - adapt conflicts when source intent can be preserved on the target branch
 - run repo-standard validation that does not require environment rebuild or refresh
@@ -37,155 +40,184 @@ If the workflow would cross a contract boundary, stop and ask the user before pr
 
 ## Usage
 ```
-/cherry-pick <pr-url>                   # Cherry-pick from a PR
-/cherry-pick <sha>                      # Cherry-pick a specific commit
-/cherry-pick <sha> --target <branch>    # Cherry-pick to specific branch
-/cherry-pick <sha-1> <sha-2> <sha-3>    # Plan and execute multiple changes
-/cherry-pick <sha-1> <sha-2> --plan-only # Plan only, do not apply
+/cherry-pick <pr-url>                          # Cherry-pick from a PR
+/cherry-pick <sha>                             # Cherry-pick a specific commit
+/cherry-pick <sha> --target <branch>           # Cherry-pick to specific branch
+/cherry-pick <sha> --force                     # Override reject-category gate
+/cherry-pick <sha-1> <sha-2> <sha-3>           # Batch: plan and execute multiple changes
+/cherry-pick <sha-1> <sha-2> --plan-only       # Plan only, do not apply
 ```
 
-## Steps
+## Single Cherry-Pick Flow
 
-1. **Plan Order if Needed**
+Each cherry-pick follows this sequence. No phase may be skipped.
 
-   If multiple PRs or SHAs are provided, or if `--plan-only` is set:
+### 1. Investigate (always Opus)
 
-   This phase owns dependency analysis, ordering, and the initial execution table.
+Run `cherry-pick-investigate.md`.
 
-   If `--plan-only` is set, stop after producing the plan report.
+- Source analysis: resolve PR to commit(s), inspect changed files, classify as functional/structural/dependency/mixed
+- Target compatibility scan: check file/module existence, API differences, detect modify/delete risk
+- Prerequisite scan: identify dependencies, check for existing fixes
 
-2. **Investigate Each Change in Order**
+Investigation produces the raw analysis. It does not make the go/no-go decision — that belongs to the gate.
 
-   For a single input, investigate that change directly.
-   For multiple inputs, process the planned sequence one change at a time.
+### 2. Gate
 
-   When the change is intended to resolve a bug, run `check-existing-fix.md` and produce its formal output block (the `## Existing Fix Status` summary with status, confidence, and evidence). The check itself is not enough — the normalized output is required so the calling workflow can branch on it.
+Run `cherry-pick-gate.md` against the investigation output.
 
-   **Bug classification**: if the PR is tagged `fix`/`bugfix` or the commit message indicates corrective behavior, treat it as a bug fix. When ambiguous (e.g., `refactor` that also fixes a defect), run the check — a false positive (checking unnecessarily) costs less than a false negative (skipping and cherry-picking a fix that's already on the target). **Exception**: skip the check for dependency upgrades, version bumps, or mixed PRs where the primary change is not an isolated defect — see `check-existing-fix.md` skip rules. When skipping, still emit the output block with `Status: SKIPPED`.
+This phase decides:
+- **Should we cherry at all?** Accept/reject based on `rules/cherry-picking.md` matrix. `--force` overrides rejection with warnings.
+- **Difficulty classification**: TRIVIAL vs NON-TRIVIAL, which determines model selection for plan and validate phases.
+- **Adapt required?** Trivial changes skip the adapt phase.
 
-   This phase produces the risk assessment for each change.
+If the gate rejects without `--force`, stop here. Record status as `Rejected` with the reason.
 
-   **Per-change complexity classification**: After investigation, classify each change:
+### 3. Plan (subagent — model set by gate)
 
-   | Signal | Mechanical | Non-Mechanical |
-   |--------|-----------|----------------|
-   | Files touched | 1–2 | 3+ |
-   | Change type | Version bump, config, import fix, one-liner | Logic change, behavioral, multi-component |
-   | Conflicts | Clean apply (no conflicts) | Conflicts expected or detected |
-   | Dependency | No new dependencies | Adds/changes dependencies |
+Run `cherry-pick-plan.md` as a subagent. Model is Sonnet for trivial, Opus for non-trivial (per gate output).
 
-   Emit a classification block per change:
-   ```markdown
-   ### Change Classification: <sha>
-   Classification: MECHANICAL / NON-MECHANICAL
-   Confidence: X/10
-   Reason: [one line]
-   ```
+The plan covers this specific cherry-pick's application strategy:
+- File exclusions and why
+- Expected conflicts and resolution approach
+- Adaptation strategy (if non-trivial)
+- Validation approach
 
-   - **Mechanical + confidence 8/10+**: fast path — apply directly, skip full adapt cycle. **Still runs diff audit via validate subagent** — clean applies are the primary scope leak vector. If a single change and `Risk: LOW`, combine investigate and apply into one phase.
-   - **Non-mechanical**: full path — investigate, adapt if needed, validate, and stop for user decisions when required.
+### 4. Plan Review (main thread)
 
-   Auto-proceed only when the helper rates the change low-risk, high-confidence, and not decision-bound.
-   Otherwise record the status in the execution table and stop for user input only where required.
+The main thread (or orchestrator in batch mode) reviews the subagent's plan.
 
-3. **Apply Each Auto-Approved Cherry-Pick Sequentially**
+Review criteria:
+- Does the plan match the investigation findings?
+- Are file exclusions justified?
+- Is the conflict resolution approach sound?
+- Are there risks the plan missed?
 
-   ```bash
-   git checkout <target-branch>
-   git cherry-pick -x <commit-hash>
-   ```
+If the plan is not acceptable, send feedback to the plan subagent and cycle back to step 3. Repeat until the plan is approved.
 
-   Always apply on the target branch sequentially, never in parallel.
+### 5. Apply (Opus)
 
-4. **Adapt Conflicts if Needed**
+Run `cherry-pick-apply.md`.
 
-   This phase owns conflict classification and code-level adaptation.
-   If the cherry-pick state is lost, do not continue blindly; return to the apply phase.
-   If a prerequisite or behavior decision is required, stop and ask the user.
+```bash
+git checkout <target-branch>
+git cherry-pick -x <commit-hash>
+```
 
-5. **Validate Each Applied Change (subagent — mandatory)**
+Always apply on the target branch. Always use `-x` to preserve source reference.
 
-   **Always run validation as a subagent**, never inline in the orchestrator thread. The thread that applied the cherry-pick must not validate its own work — the same separation principle as code review. Use `model: "sonnet"` per `rules/orchestration.md`.
+### 6. Adapt (Opus — non-trivial only)
 
-   **The diff audit is mandatory for every cherry-pick, including clean applies.** Clean applies are the highest-risk vector for scope leak — when git resolves without conflicts, nobody scrutinizes the result, and changes from adjacent commits on the source branch silently enter the target. The #38809 incident (SC-104110, P1) was a clean cherry-pick that leaked the `hideTab` guard from an adjacent commit.
+Run `cherry-pick-adapt.md`. Only when the gate classified the change as NON-TRIVIAL or when conflicts are detected during apply.
 
-   The subagent runs `cherry-pick-validate.md` which includes:
-   1. **Diff audit** — compare source commit diff vs cherry-pick result diff, flag extra files/hunks
-   2. **Build/lint/type-check** — repo-standard checks
-   3. **Targeted tests** — covering the changed area
+If a trivial change unexpectedly hits conflicts during apply, escalate to adapt — the gate classification was wrong, and adapt should treat it as non-trivial.
 
-   If the diff audit finds scope leak, the subagent reverts the leaked hunks and reports back. The orchestrator then amends the cherry-pick before pushing.
+### 7. Validate (subagent — model set by gate)
 
-   This phase also owns validation depth for dependency-manifest changes.
-   If stronger validation would require rebuilding or refreshing the environment, stop for intervention instead of doing it automatically.
+Run `cherry-pick-validate.md` as a subagent. Model is Sonnet for trivial, Opus for non-trivial (per gate output).
 
-   **Push after each successful cherry-pick**: After local validation passes, push immediately so CI runs against the change.
-   ```bash
-   git push
-   ```
+**Always run validation as a subagent**, never inline. The thread that applied the cherry-pick must not validate its own work.
 
-6. **Document the Plan and Outcome**
+**The diff audit is mandatory for every cherry-pick, including clean applies.** Clean applies are the highest-risk vector for scope leak — when git resolves without conflicts, nobody scrutinizes the result, and changes from adjacent commits on the source branch silently enter the target. The #38809 incident (SC-104110, P1) was a clean cherry-pick that leaked the `hideTab` guard from an adjacent commit.
 
-   **Planning phase** uses the full execution table (12 columns) defined in `cherry-pick-plan.md`. That table is the working artifact during investigation and apply.
+The subagent runs `cherry-pick-validate.md` which includes:
+1. **Diff audit** — compare source commit diff vs cherry-pick result diff, flag extra files/hunks
+2. **Build/lint/type-check** — repo-standard checks
+3. **Targeted tests** — covering the changed area
 
-   **Final report** uses a condensed format. Lead with the ticket outcome (what the user cares about), then the execution table, then actionable residuals:
+If the diff audit finds scope leak, the subagent reverts the leaked hunks and reports back. The orchestrator then amends the cherry-pick before pushing.
 
-   ```markdown
-   ## Cherry-Pick Summary
+**Push after each successful cherry-pick**: After local validation passes, push immediately so CI runs against the change.
+```bash
+git push
+```
 
-   [1-2 lines answering the user's original question — e.g., "The StructuredContentStripperMiddleware (the encoding fix) is now active on this branch." or "The fix from #38837 is applied; CI re-run needed to confirm."]
+## Batch Cherry-Pick Flow
 
-   [X of N applied, Y rejected, Z partial] → <target branch>
+When multiple PRs or SHAs are provided, the main agent acts as a **thin orchestrator**. It must not accumulate per-cherry context — each cherry runs in isolation.
 
-   ### Results
-   | SHA | PR | Status | Validation | Notes |
-   |-----|----|--------|------------|-------|
-   | `<sha>` | #123 | Applied | Tested | Clean apply |
-   | `<sha>` | #124 | Partial | Checked | 5 of 7 sub-fixes applied; encoding fix dropped — see below |
-   | `<sha>` | #125 | Rejected | — | Missing decorator infrastructure on target |
+### Orchestrator Responsibilities
 
-   ### Detailed Notes
-   #### `<sha>` — <summary>
-   - **Why non-trivial**: [conflict, rejection reason, or intervention point]
-   - **Adaptation details**: [What was modified and why]
-   - **What was dropped**: [specific functions, files, or sub-fixes omitted]
-   - **Residual risk**: [What remains uncertain]
+1. **Sequence planning**: Run `cherry-pick-batch-sequence.md` (Sonnet subagent) to determine execution order based on dependencies and overlap.
 
-   ### What to do next
-   - [Actionable residual items — e.g., "encoding bug likely affects target via different code path — needs separate fix"]
-   - [Validation gaps — e.g., "run pytest tests/unit_tests/mcp_service/ before merging"]
-   - [Pending PRs to monitor — e.g., "#38676 still open — pick when merged"]
-   ```
+2. **Per-cherry execution**: For each cherry in sequence, spawn a subagent that runs the full single cherry-pick flow (steps 1-7 above). Each subagent gets its own clean context.
 
-   Keep the dependency graph from the planning phase if inter-change dependencies were detected.
-   The full 12-column execution table remains in the planning output — the compact table replaces it only in the final report.
-   Add detailed notes for any row that is not `Applied` with `None` adaptation, plus any `Applied` row with notable adaptation.
+3. **Status tracking**: After each subagent completes, record the result in the execution table. If one fails, do NOT continue with subsequent picks that depend on it. Independent subsequent picks may continue.
 
-   Record lifecycle: `command-complete`
+4. **Escalation handling**: If a subagent escalates a decision, the orchestrator surfaces it to the user, gets the answer, and relays it back.
 
-   ## Continuation Checkpoint
+5. **Final report**: Collect results from all subagents and produce the document phase output.
 
-   Phases: plan / investigate / apply / adapt / validate / document
+### Why Isolation Matters
 
-   State:
-   - Target branch: <branch>
-   - Current execution table snapshot: [latest status summary]
-   - Pending intervention points: [any user decisions still needed]
+With 15 cherry-picks, if the main agent processes each one inline, by cherry #10 the context is polluted with prior diffs, conflict resolutions, and adaptation decisions. Quality degrades. Each cherry in its own subagent gets a clean context window.
+
+### `--plan-only` for Batch
+
+If `--plan-only` is set, run only the sequence planning step and per-cherry investigate + gate (in parallel where independent). Produce the execution table without applying anything.
 
 ## Sequential Cherry-Pick Safety
 
 When cherry-picking multiple commits in sequence:
 - Verify each cherry-pick completes before starting the next
-- If one fails mid-chain, do NOT continue with subsequent picks
+- If one fails mid-chain, do NOT continue with dependent picks
+- Independent picks may continue if they don't share files/modules with the failed pick
 - Clean up the failed state (`git cherry-pick --abort`) before deciding next steps
 - Document which picks succeeded and which didn't
+
+## Document the Plan and Outcome
+
+**Per-cherry tracking** uses the execution table defined in `cherry-pick-plan.md`. Every cherry-pick (single or batch) produces one. In batch mode, the orchestrator also maintains the full batch execution table from `cherry-pick-batch-sequence.md`.
+
+**Final report** uses a condensed format. Lead with the ticket outcome (what the user cares about), then the execution table, then actionable residuals:
+
+```markdown
+## Cherry-Pick Summary
+
+[1-2 lines answering the user's original question — e.g., "The StructuredContentStripperMiddleware (the encoding fix) is now active on this branch." or "The fix from #38837 is applied; CI re-run needed to confirm."]
+
+[X of N applied, Y rejected, Z partial] -> <target branch>
+
+### Results
+| SHA | PR | Status | Validation | Notes |
+|-----|----|--------|------------|-------|
+| `<sha>` | #123 | Applied | Tested | Clean apply |
+| `<sha>` | #124 | Partial | Checked | 5 of 7 sub-fixes applied; encoding fix dropped — see below |
+| `<sha>` | #125 | Rejected | — | Feature change, no --force |
+
+### Detailed Notes
+#### `<sha>` — <summary>
+- **Why non-trivial**: [conflict, rejection reason, or intervention point]
+- **Gate decision**: [PROCEED / REJECT / FORCE-PROCEED + criteria]
+- **Adaptation details**: [What was modified and why]
+- **What was dropped**: [specific functions, files, or sub-fixes omitted]
+- **Residual risk**: [What remains uncertain]
+
+### What to do next
+- [Actionable residual items — e.g., "encoding bug likely affects target via different code path — needs separate fix"]
+- [Validation gaps — e.g., "run pytest tests/unit_tests/mcp_service/ before merging"]
+- [Pending PRs to monitor — e.g., "#38676 still open — pick when merged"]
+```
+
+Keep the dependency graph from the planning phase if inter-change dependencies were detected.
+The full 12-column execution table remains in the planning output — the compact table replaces it only in the final report.
+Add detailed notes for any row that is not `Applied` with `None` adaptation, plus any `Applied` row with notable adaptation.
+
+Record lifecycle: `command-complete`
+
+## Continuation Checkpoint
+
+Phases: investigate / gate / plan / plan-review / apply / adapt / validate / document
+
+State:
+- Target branch: <branch>
+- Current execution table snapshot: [latest status summary]
+- Pending intervention points: [any user decisions still needed]
 
 ## Notes
 
 - **PROJECT.md**: Cherry-picks are branch-movement operations — the parent workflow owns any PROJECT.md update, not this command.
-
 - Always use `cherry-pick -x` to preserve source reference
-- Default to low-intervention flow when the investigation rates the move low-risk and no decision is required
-- Prefer functional over structural changes
+- `--force` overrides the gate's accept/reject decision, not any downstream phase
 - When in doubt, reject
 - Use `--plan-only` when you want dependency ordering and risk classification without applying anything

--- a/rules/cherry-picking.md
+++ b/rules/cherry-picking.md
@@ -1,43 +1,19 @@
 # Cherry-Pick Principles
 
 ## Golden Rules
-- [ ] **Understand before changing** — analyze full scope
+- [ ] **Understand before changing** — investigate fully before deciding
+- [ ] **Gate before planning** — decide whether to cherry at all before planning how
 - [ ] **Always use `cherry-pick -x`** — preserves source commit reference
 - [ ] **Always use `cherry-pick --continue` to commit** — never `git commit` directly after resolving conflicts. `--continue` preserves original author, cherry-pick metadata, and the `(cherry picked from commit ...)` trailer.
-- [ ] **Verify `.git/CHERRY_PICK_HEAD` exists before `--continue`** — if it doesn't, the cherry-pick state was lost (e.g., aborted or already committed). Running `--continue` without it will error or operate on stale state.
+- [ ] **Verify `.git/CHERRY_PICK_HEAD` exists before `--continue`** — if it doesn't, the cherry-pick state was lost. Running `--continue` without it will error or operate on stale state.
 - [ ] **Validate bug exists in target branch** — before cherry-picking a fix, confirm it's present
 - [ ] **Preserve working functionality**
 - [ ] **Adapt rather than force** — work with target architecture
 - [ ] **Verify imports/modules exist** in target branch
 - [ ] **Prefer functional over structural** — extract value, not architecture
-- [ ] **Audit cherry-pick scope** — after resolution, diff-audit the result against the source commit to detect leaked changes from adjacent commits (see validate phase)
-- [ ] **Document decisions** — what accepted, rejected, why
-
-## Accept vs Reject
-
-| Accept | Reject |
-|--------|--------|
-| Bug fixes | Architecture changes |
-| Isolated features | Unverified imports |
-| Algorithm improvements | Breaking API changes |
-| Test additions | Build system changes |
-| Documentation | File restructuring |
-
-## Decision Framework
-
-```
-Can I extract just functional improvement?
-  YES → Extract and adapt
-  NO  → Consider if needed
-
-Does target have equivalent?
-  YES → Enhance existing
-  NO  → Add without breaking
-
-Will forcing this break existing?
-  YES → Reject or find alternative
-  NO  → Proceed with caution
-```
+- [ ] **Plan is reviewed before apply** — the plan subagent's work is always reviewed by a different agent
+- [ ] **Audit cherry-pick scope** — diff-audit the result against the source commit to detect leaked changes from adjacent commits
+- [ ] **Document decisions** — what accepted, rejected, why, and any `--force` overrides
 
 ## Conflict Resolution
 

--- a/rules/orchestration.md
+++ b/rules/orchestration.md
@@ -23,6 +23,8 @@ Match subagent model to the **actual reasoning load of this specific task**, not
 
 **The decision rule**: assess the *substance* of this specific task before choosing. Default to `sonnet`. Drop to `haiku` only for purely mechanical work. Escalate to `opus` only when this specific instance genuinely requires deep reasoning. Role labels (e.g., "architecture reviewer") do not auto-promote to Opus — the actual scope does.
 
+**Cherry-pick model tiering**: Cherry-pick phases use gate-driven model selection rather than the general reasoning-load heuristic above. The gate classifies difficulty (TRIVIAL vs NON-TRIVIAL) and that classification determines models for plan, validate, and adapt phases. See `cherry-pick-gate.md` for the tier table.
+
 The orchestrator (main thread) may run on any model the user has selected — these tiers apply to **subagents** spawned from it. A Sonnet orchestrator escalating to an Opus subagent for genuinely hard work is the canonical cost-efficient pattern.
 
 ## Inline-First Principle

--- a/skills/cherry-pick-batch-sequence.md
+++ b/skills/cherry-pick-batch-sequence.md
@@ -1,0 +1,84 @@
+---
+model: sonnet
+---
+
+# Cherry-Pick Batch Sequence
+
+Use this phase when the user provides multiple commits or PRs. Determines execution order only — per-cherry planning is handled by `cherry-pick-plan.md`.
+
+## Goal
+
+Build a safe execution order for a batch of cherry-picks. Stay lightweight — this is ordering and deduplication, not deep per-change analysis.
+
+## Parallel Work
+
+For each candidate change, run these analyses in parallel when possible:
+
+1. Source analysis
+   - Resolve the PR or SHA to the actual commit(s)
+   - Inspect changed files, intent, and nearby history just enough to order and triage
+
+2. Dependency and overlap analysis
+   - Check which changes touch the same files or modules
+   - Detect imports, APIs, or modules introduced by one change and consumed by another
+
+3. Existing-fix scan
+   - Check whether the target branch already appears to contain an equivalent fix
+   - Exclude duplicates before planning order
+
+## Ordering Rules
+
+- Build a dependency graph across all requested changes
+- Topologically sort the graph
+- Independent changes may be investigated in parallel (by the orchestrator spawning subagents)
+- Actual cherry-pick application on the target branch remains sequential
+- Flag circular dependencies or ambiguous prerequisite chains as requiring user decision
+
+## Dry-Run Rule
+
+For `--plan-only`, the orchestrator will also run investigate + gate for each cherry after sequencing. This phase only handles the ordering.
+
+## Output
+
+```markdown
+## Batch Sequence Plan
+
+### Target Branch
+<branch>
+
+### Dependency Graph
+| Change | Depends On | Independent |
+|--------|------------|-------------|
+| PR #123 | — | Yes |
+| PR #124 | PR #123 | No |
+
+<short summary of inter-change dependencies>
+
+### Execution Order
+| # | SHA | PR | Description | Depends On | Notes |
+|---|-----|----|-------------|------------|-------|
+| 1 | `<sha>` | #123 | <summary> | — | Independent |
+| 2 | `<sha>` | #124 | <summary> | #123 | Must follow #123 |
+
+### Parallelizable Groups
+[List which changes can be investigated in parallel because they're independent]
+```
+
+Do not populate risk, confidence, or decision fields — those belong to per-cherry investigate and gate phases.
+
+## Full Execution Table (Batch Tracking)
+
+The orchestrator maintains this table across all cherry-picks in a batch. It is updated as each per-cherry subagent completes.
+
+| # | SHA | PR | Description | Depends On | Risk | Confidence | Decision | Status | Adaptation | Validation | Notes |
+|---|-----|----|-------------|------------|------|------------|----------|--------|------------|------------|-------|
+
+Field meanings:
+
+- `Risk`: `LOW`, `MED`, or `HIGH` (populated by per-cherry gate)
+- `Confidence`: confidence in the move as `X/10` (populated by per-cherry gate)
+- `Decision`: `Auto`, `Approval`, or `Escalate` (populated by per-cherry gate)
+- `Status`: `Planned`, `Applied`, `Partial`, `Blocked`, `Rejected`, or `Skipped`
+  - `Partial` = applied but significant portions dropped. Always requires detailed notes.
+- `Adaptation`: `None`, `Minor`, `Medium`, or `High` (see `cherry-pick-plan.md` for level definitions)
+- `Validation`: `Not run`, `Tested`, `Checked`, `Build-only`, `Structural`

--- a/skills/cherry-pick-gate.md
+++ b/skills/cherry-pick-gate.md
@@ -1,0 +1,100 @@
+# Cherry-Pick Gate
+
+Decides whether a change should be cherry-picked at all, and sets the difficulty tier that controls model selection for downstream phases.
+
+This phase consumes the output of `cherry-pick-investigate.md` and produces the go/no-go decision plus tier classification.
+
+## Inputs
+
+- Investigation output (source analysis, target compat, prereq scan)
+- `--force` flag (if set by user)
+
+## Decision: Should We Cherry?
+
+Evaluate the change against the accept/reject matrix in `rules/cherry-picking.md`:
+
+| Accept | Reject |
+|--------|--------|
+| Bug fixes | Architecture changes |
+| Isolated features | Unverified imports |
+| Algorithm improvements | Breaking API changes |
+| Test additions | Build system changes |
+| Documentation | File restructuring |
+
+### Reject-category changes
+
+If the change falls into a reject category:
+
+- **Without `--force`**: Stop. Explain why this change is not suitable for cherry-pick. List which reject criteria it hits. Suggest alternatives if applicable (e.g., "consider a targeted rewrite on the target branch instead").
+- **With `--force`**: Warn explicitly what reject criteria are being overridden, then continue. The warning must appear in the final report. Force does not skip any downstream phase — it only overrides the accept/reject gate.
+
+### Bug fixes
+
+When the change is a bug fix (tagged `fix`/`bugfix`, or commit message indicates corrective behavior):
+
+- Consume the existing-fix status from the investigation output (investigate already runs `check-existing-fix.md` — do not re-run it).
+- If `Status: FIXED_UPSTREAM` with high confidence, stop — the fix is already there.
+- If `Status: FIX_PENDING_PR`, surface the pending PR and ask whether to wait or proceed.
+- If `Status: UNFIXED` or `SKIPPED`, continue.
+
+### Features with `--force`
+
+When force-cherry-picking a feature, additionally flag:
+- Dependency additions the target branch doesn't have
+- API surface changes that may break consumers
+- Whether the feature requires follow-up work on the target branch
+
+These are warnings, not blockers — `--force` means proceed.
+
+## Difficulty Classification
+
+After the go/no-go decision, classify the change:
+
+| Signal | Trivial | Non-Trivial |
+|--------|---------|-------------|
+| Files touched | 1-2 | 3+ |
+| Change type | Version bump, config, import fix, one-liner | Logic change, behavioral, multi-component |
+| Conflicts expected | None (clean apply likely) | Conflicts expected or detected |
+| Dependencies | No new dependencies | Adds/changes dependencies |
+| Target compatibility | APIs and modules exist and match | APIs differ, modules missing or renamed |
+| Prerequisite commits | None needed | Prerequisites identified |
+
+Classify as **trivial** only when ALL trivial signals apply. Any single non-trivial signal makes the change **non-trivial**.
+
+Emit the classification:
+
+```markdown
+## Gate Decision
+
+Verdict: PROCEED / REJECT / FORCE-PROCEED
+Difficulty: TRIVIAL / NON-TRIVIAL
+Reject Criteria Hit: [list or "none"]
+Force Override: YES / NO
+
+### Model Tier
+Plan: sonnet / opus
+Validate: sonnet / opus
+Adapt Required: YES / NO
+```
+
+## Model Tier Selection
+
+The difficulty classification determines model selection for all downstream phases:
+
+| Phase | Trivial | Non-Trivial |
+|-------|---------|-------------|
+| Plan (subagent) | Sonnet | Opus |
+| Plan Review | Main thread (Opus) | Main thread (Opus) |
+| Apply | Opus | Opus |
+| Adapt | skipped | Opus |
+| Validate (subagent) | Sonnet | Opus |
+
+## Forced Non-Trivial Escalation
+
+Regardless of signals, classify as **non-trivial** when:
+
+- `--force` is overriding a reject-category change
+- Investigation flagged modify/delete risk
+- Investigation flagged prerequisite commits
+- The change is a bundled PR with multiple sub-fixes
+- Dependency manifests or lockfiles are touched

--- a/skills/cherry-pick-investigate.md
+++ b/skills/cherry-pick-investigate.md
@@ -4,18 +4,11 @@ model: opus
 
 # Cherry-Pick Investigation
 
-Use this phase before applying a cherry-pick.
+Produces the raw analysis that the gate and plan phases consume. This phase does not make the go/no-go decision — that belongs to `cherry-pick-gate.md`.
 
 ## Goal
 
-Determine whether the candidate change should:
-
-- proceed automatically
-- proceed after user approval
-- stop and escalate to planning
-
-This is the final per-change risk gate before apply.
-Do not rebuild the batch dependency graph here unless the plan phase missed a prerequisite that materially changes the outcome.
+Understand the change deeply enough for the gate to decide whether to proceed and for the plan to determine how.
 
 ## Parallel Work
 
@@ -23,15 +16,16 @@ Run these tracks in parallel when possible:
 
 1. Source analysis
    - Resolve PR URL to commit(s) if needed
-   - Inspect commit message, changed files, and nearby history in enough detail to confirm or override the provisional plan assessment
+   - Inspect commit message, changed files, and nearby history
    - Classify the change as functional, structural, dependency-related, or mixed
+   - For bundled PRs: identify and list distinct sub-fixes
 
 2. Target compatibility scan
    - Check whether touched files and modules exist on the target branch
    - Compare imports, APIs, and obvious dependency differences
    - Detect deleted or renamed target-side modules
-   - **Flag modify/delete risk**: when source files don't exist on target, explicitly note this in the output — the apply phase needs to know it will hit modify/delete conflicts and must use `git rm`, not post-apply revert. List the specific files.
-   - If `package.json`, lockfiles, or equivalent dependency manifests changed, treat validation as non-routine and call out whether build or CI verification is needed
+   - **Flag modify/delete risk**: when source files don't exist on target, explicitly list the specific files — downstream phases need this
+   - If `package.json`, lockfiles, or equivalent dependency manifests changed, flag as dependency change
 
 3. Prerequisite scan
    - Look for earlier commits the change appears to depend on
@@ -40,68 +34,51 @@ Run these tracks in parallel when possible:
 
 ## Bundled PRs
 
-When a single PR or commit contains multiple independent fixes (e.g., "fix 7 bugs" squashed into one commit):
+When a single PR or commit contains multiple independent fixes:
 
-- Identify and list the distinct sub-fixes during source analysis.
-- Assess each sub-fix individually against the target branch — some may apply cleanly while others hit architecture mismatches.
-- If sub-fixes are independent, they can be included or excluded individually. Use `Partial` status when some sub-fixes are dropped.
-- If sub-fixes are entangled (shared code paths, interdependent changes), treat the commit atomically — apply all or reject all.
-- Note in the execution table's `Notes` column how many sub-fixes the PR contains and how many were included (e.g., "5 of 7 sub-fixes applied, 2 dropped — see Detailed Notes").
+- Identify and list the distinct sub-fixes during source analysis
+- Assess each sub-fix individually against the target branch — some may apply cleanly while others hit architecture mismatches
+- If sub-fixes are independent, they can be included or excluded individually
+- If sub-fixes are entangled (shared code paths, interdependent changes), note they must be treated atomically
 
 ## Batch Execution
 
-This file describes per-change investigation. When investigating multiple independent changes, prefer parallel subagents (one per change) over sequential investigation in the main context. The within-change tracks (source, target, prereq) are typically fast enough to run sequentially inside a single agent — the bigger parallelism win is across changes.
+When investigating multiple independent changes, prefer parallel subagents (one per change) over sequential investigation in the main context. The within-change tracks (source, target, prereq) are typically fast enough to run sequentially inside a single agent — the bigger parallelism win is across changes.
 
-## Risk Assessment
+## Output
 
-Use `action-gate.md` for the final proceed/stop decision.
-
-Always end with the shared execution gate block — this is required even for LOW/Auto changes:
+Keep investigation output compact. Produce:
 
 ```markdown
-## Execution Gate
-Risk: LOW / MED / HIGH
-Confidence: X/10
-Decision Required: YES / NO
-Verification Strength: STRONG / PARTIAL / WEAK
-Recommendation: Proceed automatically / Ask for approval / Stop and escalate
+## Investigation: <sha-short> (<summary>)
+
+### Source Analysis
+Change type: functional / structural / dependency / mixed
+Files changed: [N]
+Key files: [list of most significant files]
+Sub-fixes: [if bundled PR, list them; otherwise "N/A"]
+
+### Target Compatibility
+Compatible files: [N of total]
+Modify/delete risk: [list of files or "none"]
+API differences: [list or "none detected"]
+Import/module mismatches: [list or "none detected"]
+Dependency changes: [list or "none"]
+
+### Prerequisites
+Required prior commits: [list or "none identified"]
+Existing fix status: [output from check-existing-fix.md or "not a bug fix"]
+Ordering constraints: [list or "none"]
+
+### Raw Signals for Gate
+Files touched: [N]
+New dependencies: YES / NO
+Lockfile changes: YES / NO
+Target APIs compatible: YES / NO / PARTIALLY
+Conflicts expected: YES / NO / LIKELY
+Prerequisite needed: YES / NO
 ```
 
-For cherry-pick work, set `Verification Strength` based on whether routine target-side validation is localized (`STRONG` / `PARTIAL`) or would require non-routine rebuild or environment refresh (`WEAK`).
+Avoid exhaustive file-by-file tables when most files apply cleanly. A summary line ("12 files apply cleanly, 2 need adaptation, 1 doesn't exist on target") is better than a 12-row table with "OK" repeated.
 
-**Fast path**: For single changes rated `Risk: LOW` / `Confidence >= 8/10` / `Decision: NO`, emit the gate block and proceed directly to apply without a separate presentation step. The gate block is still required — the presentation pause is what gets skipped.
-
-## Rating Rules
-
-Set `Risk: LOW` only when all of the following are true:
-
-- the change is primarily functional, not structural
-- no new dependencies, lockfile changes, or migrations are required
-- no prerequisite commit is needed
-- target-side APIs and modules are compatible or trivially adaptable
-- expected validation is routine and localized
-
-Set `Decision Required: YES` if any of the following are true:
-
-- multiple prerequisite sequences are plausible
-- the cherry-pick would require dropping or rewriting meaningful behavior
-- the change touches architecture, schema, or cross-cutting wiring
-- the right target branch or scope is ambiguous
-
-## Cherry-Pick-Specific Auto-Proceed Exceptions
-
-Even if the shared action gate would otherwise allow automatic action, stop and surface the decision instead when:
-
-- destructive cleanup is needed
-- a multi-commit sequencing choice is still unresolved
-
-When this phase overrides the batch plan, update the execution table rather than carrying two competing assessments.
-
-## Presentation
-
-Keep investigation output compact. Focus on:
-- files to exclude and why
-- key risks and adaptation needs
-- the execution gate block
-
-Avoid exhaustive file-by-file tables when most files apply cleanly. A summary line ("12 files apply cleanly, 2 excluded, 1 needs adaptation") is better than a 12-row table with "OK" repeated.
+The "Raw Signals for Gate" block is required — it provides the structured input the gate uses for its difficulty classification.

--- a/skills/cherry-pick-plan.md
+++ b/skills/cherry-pick-plan.md
@@ -1,100 +1,113 @@
----
-model: sonnet
----
-
 # Cherry-Pick Plan
 
-Use this phase when the user provides multiple commits or PRs, or requests a plan-only dry run.
+Per-cherry application strategy. This phase runs as a subagent — model is set by the gate's difficulty classification (Sonnet for trivial, Opus for non-trivial).
 
 ## Goal
 
-Build a safe execution order, identify which changes can be applied automatically, and surface only the decisions that actually need user intervention.
+Produce a concrete plan for how to apply this specific cherry-pick to the target branch. The plan is reviewed by the main thread before apply proceeds.
 
-This is a batch-level planning phase. It should stay lightweight enough to order, dedupe, and triage the requested changes.
-Do not duplicate the deeper per-change risk gate owned by `cherry-pick-investigate.md`.
+This phase consumes investigation output and gate decision. Do not re-litigate whether the cherry-pick should happen — the gate already decided that.
 
-## Parallel Work
+## Inputs
 
-For each candidate change, run these analyses in parallel when possible:
+- Investigation output (source analysis, target compat, prereq scan, file lists)
+- Gate decision (difficulty tier, adapt required, any force-override warnings)
+- Target branch name
 
-1. Source analysis
-   - Resolve the PR or SHA to the actual commit(s)
-   - Inspect changed files, intent, and nearby history just enough to order and triage the batch
+## Plan Contents
 
-2. Dependency and overlap analysis
-   - Check which changes touch the same files or modules
-   - Detect imports, APIs, or modules introduced by one change and consumed by another
+Produce a plan covering:
 
-3. Existing-fix scan
-   - Check whether the target branch already appears to contain an equivalent fix
-   - Exclude duplicates before planning order
+### 1. File Strategy
 
-## Ordering Rules
+- **Include list**: files from the source commit that apply to the target
+- **Exclude list**: files to exclude and why (e.g., CI configs, submodule pointers, files not relevant to target)
+- **Modify/delete files**: files that exist on source but not target — will need `git rm` during apply
 
-- Build a dependency graph across all requested changes.
-- Topologically sort the graph.
-- Independent changes may be investigated in parallel.
-- Actual cherry-pick application on the target branch remains sequential.
-- Flag circular dependencies or ambiguous prerequisite chains as `Decision Required: YES`.
-- Reserve final per-change `Risk`, `Confidence`, and `Decision` ratings for the investigate phase. The plan phase may populate provisional values only.
+### 2. Conflict Forecast
 
-## Dry-Run Rule
+- **Expected conflicts**: based on investigation's target compat scan, list files likely to conflict and why
+- **Resolution approach per file**: adapt to target API, import path fix, trivial rename, etc.
+- **Unknown risks**: areas where the investigation couldn't determine compatibility
 
-For `--plan-only`, stop after planning and reporting.
+### 3. Adaptation Strategy (non-trivial only)
 
-Without `--plan-only`, the plan phase should classify each change as:
+- **API differences**: target-side APIs that differ from source, how to adapt
+- **Import/module changes**: paths or modules that need updating
+- **Logic adaptation**: behavioral changes needed to fit target architecture
+- **Scope boundary**: what parts of the commit to include, what to drop
 
-- `Auto` — low risk, high confidence, no decision required
-- `Needs approval` — plausible move, but requires a user decision
-- `Reject` — not suitable for cherry-pick in current form
+### 4. Validation Approach
 
-Treat these as provisional until the investigate phase confirms them.
+- **Minimum checks**: lint/type-check commands to run
+- **Targeted tests**: specific test files/suites covering the changed area
+- **Build verification**: whether a build step is needed
+- **Gaps**: validation that would be ideal but requires environment setup
 
-## Output
-
-Always produce a plan summary before execution:
+## Output Format
 
 ```markdown
-## Cherry-Pick Plan
+## Cherry-Pick Plan: <sha-short> (<summary>)
 
-### Target Branch
-<branch>
+### File Strategy
+Include: [N files]
+Exclude: [list with reasons or "none"]
+Modify/delete expected: [list or "none"]
 
-### Dependency Graph
-| Change | Depends On | Independent |
-|--------|------------|-------------|
-| PR #123 | — | Yes |
+### Conflict Forecast
+Expected conflicts: [list with resolution approach or "none expected"]
+Unknown risks: [list or "none"]
 
-<short summary of whether inter-change dependencies were detected>
+### Adaptation Strategy
+[For non-trivial: detailed per-file approach]
+[For trivial: "Clean apply expected, no adaptation needed"]
+
+### Validation Approach
+Checks: [specific commands]
+Tests: [specific test files/suites or "none identified"]
+Gaps: [what can't be validated locally]
 
 ### Execution Table
-| # | SHA | PR | Description | Depends On | Risk | Confidence | Decision | Status | Adaptation | Validation | Notes |
-|---|-----|----|-------------|------------|------|------------|----------|--------|------------|------------|-------|
-| 1 | `<sha>` | #123 | <summary> | — | LOW | 9/10 | Auto | Planned | None | Not run | Clean apply expected |
-| 2 | `<sha>` | #124 | <summary> | #123 | MED | 7/10 | Approval | Planned | Minor | Not run | Needs prerequisite first |
+| SHA | PR | Description | Risk | Confidence | Decision | Status | Adaptation | Validation | Notes |
+|-----|----|-------------|------|------------|----------|--------|------------|------------|-------|
+| `<sha>` | #NNN | <summary> | LOW/MED/HIGH | X/10 | Auto/Approval/Escalate | Planned | None/Minor/Medium/High | Not run | <notes> |
+
+### Risk Summary
+Overall risk: LOW / MED / HIGH
+Key concern: [one line or "none"]
 ```
 
-Use these field meanings:
+The execution table is required for every cherry-pick (single or batch). It is the tracking artifact that follows the cherry through apply → adapt → validate, updated at each phase.
 
-- `Risk`: `LOW`, `MED`, or `HIGH`
-- `Confidence`: confidence in the move as `X/10`
-- `Decision`: `Auto`, `Approval`, or `Escalate`
-- `Status`: `Planned`, `Applied`, `Partial`, `Blocked`, `Rejected`, or `Skipped`
-  - `Partial` = applied but significant portions dropped due to architecture mismatch, missing prerequisites, or target incompatibility. Always requires a Detailed Notes entry explaining what was dropped and why.
-- `Adaptation`: `None`, `Minor`, `Medium`, or `High`
-  - `None` = applied mechanically, no conflict resolution
-  - `Minor` = resolved import paths, renamed variables, or trivial API differences
-  - `Medium` = rewrote logic to fit target-side APIs or extracted functional subset from a mixed commit
-  - `High` = dropped significant chunks (entire functions, files, or bug fixes) because the target lacks required architecture. Requires user awareness — always pair with a Detailed Notes entry.
-- `Validation`: `Not run`, `Tested`, `Checked`, `Build-only`, `Structural`, or a short repo-specific equivalent
+## Plan Review Cycle
 
-Do not overload the `Risk` field with prose. Put the explanation in `Notes`.
+This plan will be reviewed by the main thread (Opus). If the review sends feedback:
 
-After execution, update the same execution table rather than emitting a separate parallel format.
+1. Read the feedback carefully
+2. Revise the plan to address concerns
+3. Re-emit the full plan (not just the changed sections)
+4. Repeat until approved
 
-Below the table, include detailed sections only for non-trivial rows:
+Common review feedback:
+- "Missing file X from exclude list" — add it with justification
+- "Conflict approach for Y is wrong, target uses Z API" — revise adaptation strategy
+- "Risk is understated" — re-evaluate and adjust
+- "This should be rejected, not planned" — the plan subagent does not override the gate, but can note disagreement for the reviewer
 
-- `Needs adaptation`
-- `Blocked`
-- `Rejected`
-- `Intervention required`
+## Adaptation Severity Definitions
+
+Used in execution tables across cherry-pick phases:
+
+- `None` = applied mechanically, no conflict resolution
+- `Minor` = resolved import paths, renamed variables, or trivial API differences
+- `Medium` = rewrote logic to fit target-side APIs or extracted functional subset from a mixed commit
+- `High` = dropped significant chunks (entire functions, files, or bug fixes) because the target lacks required architecture. Requires user awareness — always pair with detailed notes.
+
+## Bundled PRs
+
+When a single PR contains multiple independent fixes:
+
+- List each sub-fix and its applicability to the target
+- Recommend which to include/exclude
+- If sub-fixes are entangled, treat atomically
+- Note in plan: "N of M sub-fixes planned for inclusion"

--- a/skills/cherry-pick-validate.md
+++ b/skills/cherry-pick-validate.md
@@ -31,7 +31,6 @@ Run this **before** build/test validation. A clean build doesn't catch unrelated
 
 **This step is mandatory for every cherry-pick, including clean applies with zero conflicts.** Clean applies are the highest-risk vector for scope leak — git silently picks up the source branch's current state of conflicting regions, which may include changes from adjacent commits that happened to touch the same lines. No conflicts are raised, no scrutiny is triggered, and the leaked code ships.
 
-
 1. Get the source commit's diff: `git diff <source-commit>^..<source-commit>`
 2. Get the cherry-pick result diff: `git diff HEAD^..HEAD`
 3. Compare file-by-file:

--- a/skills/cherry-pick-validate.md
+++ b/skills/cherry-pick-validate.md
@@ -31,6 +31,7 @@ Run this **before** build/test validation. A clean build doesn't catch unrelated
 
 **This step is mandatory for every cherry-pick, including clean applies with zero conflicts.** Clean applies are the highest-risk vector for scope leak — git silently picks up the source branch's current state of conflicting regions, which may include changes from adjacent commits that happened to touch the same lines. No conflicts are raised, no scrutiny is triggered, and the leaked code ships.
 
+
 1. Get the source commit's diff: `git diff <source-commit>^..<source-commit>`
 2. Get the cherry-pick result diff: `git diff HEAD^..HEAD`
 3. Compare file-by-file:

--- a/skills/cherry-pick-validate.md
+++ b/skills/cherry-pick-validate.md
@@ -1,12 +1,10 @@
----
-model: sonnet
----
-
 # Cherry-Pick Validate
 
 Use this phase after a cherry-pick applies cleanly or after conflict resolution completes.
 
 **This phase must always run as a subagent**, never inline in the orchestrator thread. The thread that applied the cherry-pick must not validate its own work.
+
+**Model selection**: Set by the gate's difficulty classification — Sonnet for trivial, Opus for non-trivial. The caller (main thread or orchestrator) is responsible for spawning this subagent with the correct model.
 
 ## Goal
 
@@ -29,21 +27,63 @@ Avoid parallel validation when the project's test/build tooling fights for the s
 
 Run this **before** build/test validation. A clean build doesn't catch unrelated changes that happen to compile.
 
-**This step is mandatory for every cherry-pick, including clean applies with zero conflicts.** Clean applies are the highest-risk vector for scope leak — git silently picks up the source branch's current state of conflicting regions, which may include changes from adjacent commits that happened to touch the same lines. No conflicts are raised, no scrutiny is triggered, and the leaked code ships.
+**This step is mandatory for every cherry-pick, including clean applies with zero conflicts.** This intentionally re-checks scope even when the adapt phase already ran its own leak detection — defense in depth. Do not skip this because adapt "already checked." Clean applies are the highest-risk vector for scope leak — git silently picks up the source branch's current state of conflicting regions, which may include changes from adjacent commits that happened to touch the same lines. No conflicts are raised, no scrutiny is triggered, and the leaked code ships.
+
+### Step 1: Mechanical Pre-Check (bash — run first)
+
+Run these commands to produce a mechanical comparison. These are not LLM judgment calls — they are deterministic checks that flag discrepancies for investigation.
+
+```bash
+# 1. File list comparison
+SOURCE_FILES=$(git diff --name-only <source-commit>^..<source-commit> | sort)
+RESULT_FILES=$(git diff --name-only HEAD^..HEAD | sort)
+
+# 2. Find extra files in cherry-pick result that weren't in source
+EXTRA_FILES=$(comm -13 <(echo "$SOURCE_FILES") <(echo "$RESULT_FILES"))
+
+# 3. Find missing files (in source but not in result — may be legitimate exclusion)
+MISSING_FILES=$(comm -23 <(echo "$SOURCE_FILES") <(echo "$RESULT_FILES"))
+
+# 4. Per-file line count comparison for shared files
+SHARED_FILES=$(comm -12 <(echo "$SOURCE_FILES") <(echo "$RESULT_FILES"))
+for f in $SHARED_FILES; do
+  SOURCE_LINES=$(git diff --stat <source-commit>^..<source-commit> -- "$f" | tail -1)
+  RESULT_LINES=$(git diff --stat HEAD^..HEAD -- "$f" | tail -1)
+  echo "$f | source: $SOURCE_LINES | result: $RESULT_LINES"
+done
+```
+
+**Interpretation rules (mechanical, no judgment):**
+- **Extra files found** → scope leak until proven otherwise. Each must be investigated in step 2.
+- **Line count differs by >20% for a shared file** → flag for hunk-level investigation in step 2. Minor differences are expected from adaptation (import paths, API names).
+- **Both checks clean** → still run step 2 (LLM hunk audit), but with higher confidence. Note "mechanical pre-check clean" in the scope audit.
+
+### Step 2: LLM Hunk-Level Audit
+
+Now investigate anything the mechanical check flagged, plus do a full hunk comparison:
 
 1. Get the source commit's diff: `git diff <source-commit>^..<source-commit>`
 2. Get the cherry-pick result diff: `git diff HEAD^..HEAD`
 3. Compare file-by-file:
-   - **Extra files**: any file changed in the cherry-pick that wasn't in the source commit is a leak. Revert it with `git checkout HEAD^ -- <file>` and amend.
+   - **Extra files** (already flagged by mechanical check): revert with `git checkout HEAD^ -- <file>` and amend. No exceptions unless the file is a legitimate adaptation (new test file for the cherry-picked change).
    - **Extra hunks**: within a shared file, any hunk in the cherry-pick diff that has no corresponding change in the source diff is a leak candidate. It may be a legitimate adaptation (e.g., import path change for the target branch) or an accidental pickup from an adjacent commit.
 4. For each extra hunk, determine origin: `git log --oneline --all -S "<leaked line>" -- <file>` — if it belongs to a different commit than the one being cherry-picked, it's a leak.
-5. Report findings as a **Scope Audit** block:
+
+### Step 3: Report
 
 ```markdown
 ## Scope Audit
+
+### Mechanical Pre-Check
 Files in source: [N] | Files in cherry-pick: [M]
 Extra files: [list or "none"]
+Missing files: [list or "none"]
+Line count divergence: [list of flagged files or "none"]
+Mechanical verdict: CLEAN / FLAGGED
+
+### Hunk-Level Audit
 Extra hunks: [list with origin commit or "none"]
+Legitimate adaptations: [list or "none"]
 Verdict: [clean / leaked — reverted / leaked — kept with justification]
 ```
 


### PR DESCRIPTION
## Summary

- **Gate phase**: New `cherry-pick-gate.md` skill decides go/no-go before any work starts, classifies difficulty (TRIVIAL vs NON-TRIVIAL), and sets model selection for downstream phases. `--force` overrides rejection with warnings.
- **Plan-review cycle**: Each cherry-pick now runs investigate → gate → plan (subagent) → review plan → apply, instead of jumping straight to application. Plan review catches bad strategies before code changes.
- **Subagent isolation**: validate phase runs as an isolated subagent to prevent scope leak from bleeding changes across cherry-picks in a batch.
- **Mandatory diff audit**: after application, a mechanical diff check verifies only the intended files were touched — detects accidental scope bleed.
- **New skills**: `cherry-pick-gate.md`, `cherry-pick-batch-sequence.md`, `cherry-pick-adapt.md`; significant rework of `cherry-pick-plan.md`, `cherry-pick-investigate.md`, `cherry-pick-validate.md`

## Test plan
- [ ] Single SHA cherry-pick — verify gate, plan, and validate phases all run in sequence
- [ ] Batch cherry-pick — verify each change is processed independently with subagent isolation
- [ ] Rejected cherry-pick — verify gate stops the workflow cleanly without applying anything
- [ ] `--force` flag — verify gate rejection is overridden with warnings intact
- [ ] Conflict case — verify adapt phase triggers and preserves source intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)