### PR TITLE
feat: add /test-pr command for manual PR testing via browser

### DIFF
--- a/commands/test-pr.md
+++ b/commands/test-pr.md
@@ -1,0 +1,170 @@
+# /test-pr - Manual PR Testing via Browser
+
+@{{TOOLKIT_DIR}}/rules/input-detection.md
+@{{TOOLKIT_DIR}}/rules/preset-environments.md
+
+> **When**: You want to manually verify a PR's changes work correctly in a running local app.
+> **Produces**: Scenario-by-scenario pass/fail results with screenshot evidence.
+
+Uses Playwright MCP to drive a real browser. Project-agnostic — works for any web app on localhost.
+
+## Usage
+
+```
+/test-pr <pr-number>
+/test-pr apache/superset#28456
+/test-pr https://github.com/owner/repo/pull/123
+/test-pr <pr-number> --url http://localhost:3000   # explicit app URL
+/test-pr <pr-number> --checkout                    # check out PR branch first
+/test-pr <pr-number> --smoke                       # 3 scenarios max, fast
+```
+
+## Prerequisite
+
+**The app must already be running locally.** This command does not start your dev server — run that yourself first (`npm run dev`, `docker compose up`, etc.) before invoking `/test-pr`.
+
+Use `--checkout` if you haven't switched to the PR branch yet. After checkout the command pauses so you can restart your dev server if needed.
+
+## Steps
+
+### 1. Resolve PR Context
+
+Detect the input format per `rules/input-detection.md` and fetch:
+
+```bash
+gh pr view $REF --json number,title,body,author,baseRefName,headRefName,files,additions,deletions
+gh pr diff $REF
+```
+
+Extract: PR number, title, description, author, changed files, and any "how to test" notes in the PR body.
+
+### 2. Checkout Branch (only with --checkout)
+
+```bash
+gh pr checkout $PR_NUMBER
+```
+
+After switching branches, pause and tell the user:
+
+> "Switched to PR branch `<branch>`. If your dev server needs restarting to pick up these changes, do that now — then reply to continue."
+
+Wait for confirmation before proceeding to step 3.
+
+### 3. Detect App URL
+
+If `--url` was provided, use it directly and skip probing.
+
+Otherwise probe common dev ports:
+
+```bash
+for port in 3000 4000 5000 8000 8080 8088 9000 9001; do
+  code=$(curl -sf -o /dev/null -w "%{http_code}" --connect-timeout 1 http://localhost:$port/ 2>/dev/null)
+  [ "$code" != "000" ] && [ -n "$code" ] && echo "localhost:$port -> HTTP $code"
+done
+```
+
+Also check Docker port mappings:
+
+```bash
+docker ps --format "{{.Names}}\t{{.Ports}}" 2>/dev/null | grep -E "0\.0\.0\.0:[0-9]+->"
+```
+
+Decision:
+- **One result**: use it, note in-line ("Using http://localhost:3000")
+- **Multiple results**: show the list and ask which one is the app under test
+- **None found**: tell the user to start the app and provide the URL — do not proceed until resolved
+
+### 4. Assess Impact
+
+Run `qa-assess-impact.md` on the PR diff and changed files. This classifies the touched workflows as CORE, STANDARD, or PERIPHERAL and determines how many smoke scenarios to generate.
+
+### 5. Derive Smoke Scenarios
+
+Run `pr-smoke-scenarios.md` with:
+- PR title, description, and author notes
+- List of changed files and diff
+- Impact assessment from step 4
+
+This produces 3–7 focused scenarios. With `--smoke`, cap at 3 regardless of impact.
+
+Show the scenario list to the user before executing. If they want to adjust (add, remove, or reword scenarios), accept changes before proceeding.
+
+### 6. Execute via Playwright MCP
+
+For each scenario in order:
+
+1. Navigate to the relevant page at the app URL from step 3
+2. Perform the described actions using Playwright MCP
+3. Take a screenshot at the primary verification point (name it `scenario-<N>-<short-name>.png`)
+4. Check console for errors: `browser_console_messages`
+5. Record the outcome: **PASS**, **FAIL**, or **BLOCKED**
+
+**Auth handling**: Determine credential strategy from the app URL per `rules/preset-environments.md`:
+- **Staging** (URL contains `stg.`): use `$PRESET_STG_BOT_LOGIN` / `$PRESET_STG_BOT_PASSWORD`. If either env var is unset, mark all scenarios BLOCKED and tell the user to set them before retrying.
+- **Local dev**: try `admin`/`admin` then `admin`/`general`. If both fail, mark all scenarios BLOCKED and ask the user for credentials.
+- **Production**: stop immediately — do not run automated tests against production.
+
+**On FAIL**: Take an additional screenshot showing the error state. Do not retry — move to the next scenario.
+
+**On BLOCKED**: Note what prerequisite was missing (auth, data, feature flag). Move on.
+
+Do not run scenarios in parallel — sequential execution keeps evidence clean.
+
+### 7. Report
+
+```markdown
+## Test-PR Complete
+
+PR: #<number> — <title>
+Branch: <head-branch>
+App: <url>
+Impact: CORE / STANDARD / PERIPHERAL
+
+### Results
+
+| # | Scenario | Tag | Result | Notes |
+|---|----------|-----|--------|-------|
+| 1 | <name> | [new/fix/guard] | ✅ PASS | — |
+| 2 | <name> | [fix] | ❌ FAIL | <what happened> |
+| 3 | <name> | [guard] | ⚠️ BLOCKED | <what was missing> |
+
+### Summary
+- <N> passed, <N> failed, <N> blocked of <N> total
+
+### Failures
+[For each FAIL — omit section if none:]
+**Scenario <N> — <name>**
+- Expected: <what should have happened>
+- Actual: <what happened instead>
+- Screenshot: scenario-<N>-fail.png
+- Console errors: <if any, or "none">
+
+### Blocked
+[For each BLOCKED — omit section if none:]
+**Scenario <N> — <name>**: <what was needed — auth, data, feature flag>
+
+### Next Steps
+[All pass:] PR looks good to merge.
+[Failures:] Feed findings back to the PR author — specific failures listed above.
+[Blocked:] Resolve blockers above and re-run `/test-pr <number>`.
+```
+
+Record lifecycle: `command-complete`
+
+## Continuation Checkpoint
+
+Phases: resolve-pr / detect-url / assess-impact / derive-scenarios / confirm-scenarios / execute / report
+
+State:
+- PR: <number> — <title>
+- App URL: <url or pending>
+- Impact: <CORE / STANDARD / PERIPHERAL>
+- Scenarios: <N total, N complete, N remaining>
+- Results so far: <N pass, N fail, N blocked>
+
+## Notes
+- **This command tests what is currently running** — make sure the right branch is checked out and the app is up before running
+- For full QA validation with a curated test plan iterated to quality threshold, use `/run-test-plan` instead
+- For running the project's existing automated Playwright test suite (`.spec.ts` files), use the `run-playwright-local.md` skill instead
+- Does not modify code or file bugs — test-only output
+- The `--smoke` flag is useful for a quick pre-merge sanity check; omit it for more thorough coverage on CORE-impact PRs

--- a/rules/preset-environments.md
+++ b/rules/preset-environments.md
@@ -1,0 +1,44 @@
+# Preset Environments
+
+Reference for Preset-specific environments and how to reach them during testing.
+
+## Staging Credentials
+
+When testing **Manager** or **Superset-shell** against a staging environment, use these env vars for authentication — never hardcode credentials:
+
+| Env Var | Purpose |
+|---------|---------|
+| `PRESET_STG_BOT_LOGIN` | Login / username for staging bot account |
+| `PRESET_STG_BOT_PASSWORD` | Password for staging bot account |
+
+Read them at test time:
+
+```bash
+echo $PRESET_STG_BOT_LOGIN       # verify the var is set
+echo $PRESET_STG_BOT_PASSWORD     # verify the var is set
+```
+
+If either is unset, stop and tell the user:
+
+> "Staging credentials not found. Set `PRESET_STG_BOT_LOGIN` and `PRESET_STG_BOT_PASSWORD` in your shell environment, then retry."
+
+Do not fall back to guessing common dev passwords for staging — the bot account credentials are required.
+
+## Environment Detection
+
+Identify which environment is under test by the app URL:
+
+| URL Pattern | Environment | Credentials |
+|-------------|-------------|-------------|
+| `localhost:*` | Local dev | Try `admin`/`admin`, `admin`/`general` |
+| `*.stg.preset.io` or `stg.` in hostname | Staging | `PRESET_STG_BOT_LOGIN` / `PRESET_STG_BOT_PASSWORD` |
+| `*.preset.io` (no `stg`) | Production | Do not run automated tests |
+
+**Never run automated browser tests against production.**
+
+## Preset Products
+
+| Product | Typical local port | Staging URL pattern |
+|---------|-------------------|---------------------|
+| Manager | 3000 | `manager.stg.preset.io` |
+| Superset-shell | 8088 | `*.stg.preset.io` |

--- a/skills/pr-smoke-scenarios.md
+++ b/skills/pr-smoke-scenarios.md
@@ -1,0 +1,96 @@
+---
+model: sonnet
+---
+
+# PR Smoke Scenarios
+
+Derive a focused, runnable smoke-test scenario list from a PR diff and description. Produces 3–7 scenarios that directly verify the PR's stated changes and protect the most critical adjacent behavior.
+
+## When to Use
+
+- Called by `/test-pr` before browser execution
+- When you need a quick, targeted scenario set for a specific change — not a full QA matrix
+
+## Input
+
+The caller provides:
+- PR title, description, and author notes
+- List of changed files and a diff summary
+- Impact assessment (CORE / STANDARD / PERIPHERAL) from `qa-assess-impact.md`
+
+## Steps
+
+### 1. Extract the PR's Claims
+
+Read the PR title and description to identify:
+- What the PR claims to fix or add
+- Any explicit acceptance criteria or "how to test" notes from the author
+- The "before" state and expected "after" state
+
+If the PR links to an issue or ticket, treat that as additional context for expected behavior.
+
+### 2. Trace Changed Behavior
+
+For each changed file in the diff:
+- Identify what user-facing action triggers this code path
+- Identify what the expected new behavior is
+- Note adjacent behavior that could regress
+
+Prioritize:
+- Entry points (UI actions, API calls, route changes) over internal helpers
+- CORE workflows over STANDARD over PERIPHERAL
+- What the PR claims to fix/add over generic smoke coverage
+
+### 3. Write Scenarios
+
+Write 3–7 scenarios. Scale by impact:
+- PERIPHERAL: 3 scenarios (happy path + 1 regression guard)
+- STANDARD: 4–5 scenarios (happy path + 1 edge case + regression guards)
+- CORE: 6–7 scenarios (happy path + 2 edge cases + 2–3 regression guards on adjacent CORE flows)
+
+Each scenario must be:
+- **Action-first** — starts with a concrete navigation or interaction ("Go to X", "Click Y", "Submit form Z with values A, B")
+- **Outcome-clear** — states exactly what constitutes a pass ("Assert no error banner", "Verify value shown is Y", "Confirm redirect to /dashboard")
+- **Independent** — can run without relying on another scenario's side effects
+- **Targeted** — directly verifies the PR's change OR protects an adjacent flow likely to regress
+
+Tag each scenario:
+- `[new]` — verifies new behavior this PR adds
+- `[fix]` — verifies the bug this PR claims to fix (include what the broken behavior was)
+- `[guard]` — protects adjacent behavior that could regress from this change
+
+### 4. Note Setup Requirements
+
+Identify any prerequisites the executor will need:
+- Auth state (logged in as what role?)
+- Required seed data or fixtures
+- Feature flags that must be enabled
+- Environment-specific constraints
+
+## Output
+
+```markdown
+## PR Smoke Scenarios
+
+PR: #<number> — <title>
+Impact: CORE / STANDARD / PERIPHERAL
+Scenarios: <N>
+
+### Scenario 1 [new/fix/guard]: <short name>
+- **Goal**: <one sentence — what this verifies and why it matters>
+- **Steps**: <concrete navigation + actions>
+- **Pass if**: <exactly what to see or not see>
+
+### Scenario 2 ...
+
+### Setup Notes
+- Auth: <role required, or "any logged-in user">
+- Data: <required seed data or "use existing dev data">
+- Flags: <feature flags, or "none">
+```
+
+## Notes
+- Favor specificity over breadth — 4 sharp scenarios beat 7 vague ones
+- `[guard]` scenarios should cover the most-traveled adjacent path, not every possible regression
+- If the PR description includes "how to test" or "steps to reproduce" notes, translate those directly into scenarios — the author knows where to look
+- For bug fixes, the `[fix]` scenario should describe what the broken state looked like so the executor can confirm it no longer occurs


### PR DESCRIPTION
## Summary

- New `/test-pr` command that drives a real browser via Playwright MCP to smoke-test a PR's changes against a running local app
- New `pr-smoke-scenarios` skill that derives 3–7 focused, runnable test scenarios directly from a PR diff and description
- New `preset-environments` rule for credential and URL handling across local dev and staging environments

## How it works

1. Resolves the PR, fetches diff and changed files
2. Optionally checks out the PR branch (`--checkout`)
3. Probes for a running local app or accepts `--url`
4. Runs impact assessment, then derives smoke scenarios via `pr-smoke-scenarios`
5. Shows scenarios to the user for confirmation before executing
6. Drives the browser via Playwright MCP — one screenshot per scenario, sequential execution
7. Posts a pass/fail report

## Test plan
- [ ] `/test-pr <number>` against a running local app — verify scenario derivation and browser execution
- [ ] `--smoke` flag — verify cap at 3 scenarios
- [ ] `--checkout` flag — verify branch switch and pause for server restart
- [ ] No app running — verify it asks for URL rather than proceeding blindly
- [ ] Staging URL — verify it uses `$PRESET_STG_BOT_LOGIN` / `$PRESET_STG_BOT_PASSWORD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)