### PR TITLE
feat: default QA to Playwright video evidence and auto-post results to Shortcut/GitHub PR

### DIFF
--- a/commands/run-test-plan.md
+++ b/commands/run-test-plan.md
@@ -1,6 +1,7 @@
 # /run-test-plan - Standalone QA Validation
 
 @{{TOOLKIT_DIR}}/rules/input-detection.md
+@{{TOOLKIT_DIR}}/rules/preset-environments.md
 @{{TOOLKIT_DIR}}/skills/review-testplan.md
 
 > **When**: You want to validate a feature area, story, PR, or existing test-plan doc without fixing code in the same workflow.
@@ -51,19 +52,32 @@
 
 5. **Capture Evidence**
 
-   Capture only the artifacts that materially improve confidence or explain failures.
+   Record Playwright video for every UI scenario. One video per logical flow.
+   Use `recordVideo: { dir: 'qa-evidence/videos/', size: { width: 1280, height: 720 } }` when launching the Playwright browser context.
+   Name files descriptively: `sc-<id>-<scenario>.webm` or `<scenario>.webm`.
+   Supplement with console logs or API output only when video alone doesn't explain a failure.
 
-6. **Display Findings**
+6. **Report Findings**
 
-   Summarize the results locally.
-   Do not:
-   - auto-file bugs
-   - auto-route into `/fix-bug`
-   - auto-report to Shortcut
+   Post a narrative report using the QA Verification template from `shortcut-report.md`.
 
-   External reporting remains a separate manual follow-up.
+   **If a Shortcut story is known** (provided as input, or from PROJECT.md):
+   - Upload video evidence to the story
+   - Post the report as a story comment
+
+   **If a GitHub PR is known** (provided as input):
+   - Upload video evidence to the story if one is linked, otherwise note local paths
+   - Post the report as a PR comment
+
+   **Otherwise**:
+   - Display the report locally using the same template, with video file paths
+
+   Do not auto-file bugs or auto-route into `/fix-bug`.
 
 7. **Summary**
+
+   Always display locally, regardless of whether external reporting happened:
+
    ```markdown
    ## Run-Test-Plan Complete
 
@@ -80,7 +94,11 @@
    - [PASS / FAIL / BLOCKED / SKIP by scenario]
 
    ### Evidence
+   - [Video files with paths]
    - [Best proof for failures or high-value passes]
+
+   ### Reported To
+   - [Shortcut story link / GitHub PR link / local only]
 
    ### Risks / Blockers
    - [What could not be executed or remains unclear]

--- a/skills/qa-execute-use-cases.md
+++ b/skills/qa-execute-use-cases.md
@@ -23,15 +23,13 @@ Run the relevant scenarios against a real environment, record the outcomes clear
 
 ## Evidence Capture
 
-After execution, capture only the evidence that materially improves confidence:
+After execution, capture video evidence for every UI scenario:
 
-1. Capture the smallest useful artifact set for each scenario:
-   - screenshot for visual failures
-   - Playwright video for repro-heavy UI paths
-   - console, network, or API output when it explains the failure
-2. Keep naming descriptive and tied to the scenario or issue.
-3. Save artifacts under a stable local structure such as `qa-evidence/<scenario>/`.
-4. Record which artifact actually proves the behavior instead of dumping everything.
+1. **Default to video**: When testing via Playwright, always record video (`recordVideo: { dir: 'qa-evidence/videos/', size: { width: 1280, height: 720 } }`). One video per logical flow — not one giant recording.
+2. Name files descriptively: `sc-<id>-<what-was-tested>.webm` or `<scenario-name>.webm`.
+3. Save artifacts under `qa-evidence/<scenario>/`.
+4. Supplement with console logs or API output when they explain a failure that video alone doesn't capture.
+5. Identify the single best proof artifact for each scenario.
 
 ## Output
 

--- a/skills/shortcut-report.md
+++ b/skills/shortcut-report.md
@@ -1,0 +1,156 @@
+---
+model: sonnet
+---
+
+# Shortcut Report
+
+Post structured reports (QA results, fix summaries, test findings) to Shortcut stories with evidence and metadata updates.
+
+## When to Use
+
+- After QA validation, test execution, or bug triage produces results that belong on a Shortcut story
+- When a fix has been verified and the story needs a closing summary
+- When evidence (screenshots, videos, logs) needs to be attached and referenced in a comment
+
+## Prerequisites
+
+- `$SHORTCUT_API_TOKEN` must be set
+- Story ID must be known (numeric ID or `sc-NNNNN` format)
+- Use the `shortcut-fetch` skill patterns for API access and retry logic
+
+@{{TOOLKIT_DIR}}/rules/shortcut-api.md
+
+## Core Steps
+
+1. **Resolve the story**
+
+   Extract the numeric ID from `sc-NNNNN`, URL, or raw number.
+   Fetch the story to confirm it exists and get current state:
+   ```bash
+   shortcut_call 'curl -s "https://api.app.shortcut.com/api/v3/stories/<id>" -H "Shortcut-Token: $SHORTCUT_API_TOKEN"'
+   ```
+
+2. **Upload evidence** (if any)
+
+   Upload files before posting the comment so the comment can reference the hosted URLs.
+   Use the `/files` endpoint (not `/stories/<id>/files`), linking via `story_id`:
+   ```bash
+   shortcut_call 'curl -s -X POST "https://api.app.shortcut.com/api/v3/files" \
+     -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
+     -F "file0=@<path>" \
+     -F "story_id=<id>"'
+   ```
+   Do not pass `description` as a form field — it causes a validation error.
+   Capture the returned `url` for embedding in the comment.
+   Name video files descriptively: `sc-<id>-<what-was-tested>.webm`.
+
+3. **Post the report comment**
+
+   Use the appropriate template from the Report Templates section below.
+   ```bash
+   shortcut_call 'curl -s -X POST "https://api.app.shortcut.com/api/v3/stories/<id>/comments" \
+     -H "Content-Type: application/json" \
+     -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
+     -d "{\"text\": \"<markdown body>\"}"'
+   ```
+   Escape the markdown body for JSON. For long reports, build the JSON with Python to handle newlines safely.
+
+4. **Link PR** (if applicable)
+
+   ```bash
+   shortcut_call 'curl -s -X PUT "https://api.app.shortcut.com/api/v3/stories/<id>" \
+     -H "Content-Type: application/json" \
+     -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
+     -d "{\"external_links\": [\"<github-pr-url>\"]}"'
+   ```
+   Note: this replaces all external links. Fetch existing links first and merge.
+
+5. **Update story metadata** (if needed)
+
+   Update state, labels, custom fields, or estimate:
+   ```bash
+   shortcut_call 'curl -s -X PUT "https://api.app.shortcut.com/api/v3/stories/<id>" \
+     -H "Content-Type: application/json" \
+     -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
+     -d "{\"workflow_state_id\": <state_id>}"'
+   ```
+   Fetch workflow states from `/workflows` to map names to IDs. Cache per session.
+
+## Report Template
+
+Reports should read like a human QA tester wrote them — narrative, concise, evidence-linked. No tables, no metadata headers, no PASS/FAIL grids. Just tell the story of what you did and what you found.
+
+### Structure
+
+```markdown
+## QA Verification — PASS ✅ / FAIL ❌ / PARTIAL ⚠️
+
+**Tested on**: <environment URL or description> (<version/branch info>)
+**Date**: <YYYY-MM-DD>
+**Tester**: <who or what ran the test>
+
+### Repro steps followed:
+1. <what you actually did, step by step>
+2. <be specific — name the dashboard, chart, page, action>
+3. <include what you looked for and how you verified>
+
+### Result:
+**<One-sentence verdict.>** <2-3 sentences of narrative explaining what you observed. Be specific about what rendered, what didn't break, what you checked.>
+
+### Evidence:
+[<descriptive-filename.webm>](<shortcut media URL>)
+```
+
+### Writing Guidelines
+
+- **Narrative over structure**: "Opened the dashboard, scrolled through all charts, hovered over cells to check for artifacts" beats "Scenario 1: Load dashboard: PASS"
+- **Specific over generic**: Name the actual dashboard, chart, page, feature flag, user role
+- **One video beats ten screenshots**: Record a Playwright video of the full repro flow
+- **Verdict first, then details**: Lead with whether it passed, then explain what you saw
+- **Link evidence inline**: Embed the video/screenshot URL directly, don't put it in a separate section
+- **Keep it short**: If the fix works, say so in 3-4 sentences. Save long reports for failures.
+
+### Example (real — sc-98396)
+
+```markdown
+## QA Verification — PASS ✅
+
+**Tested on**: https://example.us1a.app-stg.preset.io (staging 6.0.0.6rc1)
+**Date**: 2026-02-20
+**Tester**: Playwright automation
+
+### Repro steps followed:
+1. Opened the existing "Treemap" chart (slice_id=14) from the World Bank's Data dashboard in Explore view
+2. Chart rendered with dimensions: region, country_code and metric: Population Total
+3. Visually inspected all treemap category rectangles across all regions
+4. Hovered over multiple cells (CHN, IND, JPN, RUS, BRA, NGA) to verify no white lines appear on hover
+
+### Result:
+**Bug appears fixed.** No white vertical lines visible in the middle of any treemap category cells. The category rectangles render cleanly with solid colors and proper borders between cells only (not through them).
+
+### Evidence:
+[sc-98396-treemap-no-white-lines.webm](https://media.app.shortcut.com/...)
+```
+
+## Output
+
+After posting, confirm what was done:
+
+```markdown
+## Shortcut Report Posted
+
+- Story: sc-<id> (<story name>)
+- Comment: posted (<comment link or confirmation>)
+- Evidence: <N files uploaded / none>
+- PR linked: <yes / no>
+- State updated: <new state / unchanged>
+```
+
+## Notes
+
+- Always fetch the story first to confirm it exists and get current state
+- Upload evidence before posting comments so URLs are available for embedding
+- Use Python for JSON body construction when the report contains newlines or special characters
+- When updating `external_links`, merge with existing links — don't replace
+- Prefer video evidence over screenshots for complex UI flows
+- Keep reports factual — no speculation about cause or impact beyond what evidence shows


### PR DESCRIPTION
## Summary

- `run-test-plan` and `qa-execute-use-cases` now record Playwright video for every UI scenario by default (one video per logical flow, named descriptively)
- Results are auto-posted to the linked Shortcut story or GitHub PR when context is known — no manual follow-up needed
- New `shortcut-report` skill handles evidence upload, narrative comment posting, and optional story metadata updates

## Changes

- **`commands/run-test-plan.md`** — Step 5 defaults to `recordVideo` for all UI scenarios; Step 6 routes the report to Shortcut, GitHub PR, or local display depending on what context is available
- **`skills/qa-execute-use-cases.md`** — evidence capture simplified: video is the default, console/network logs are supplements for failures video alone doesn't explain
- **`skills/shortcut-report.md`** (new) — structured skill for posting QA reports to Shortcut: uploads evidence files, posts a narrative comment using a human-readable template, optionally links PR and updates story state

## Test plan
- [ ] Run `/run-test-plan` with a Shortcut story in context — verify video is recorded and report is posted as a story comment
- [ ] Run with a GitHub PR in context but no Shortcut story — verify report posts as a PR comment
- [ ] Run with neither — verify report displays locally with video file paths
- [ ] Verify `shortcut-report` correctly uploads a video and embeds the hosted URL in the comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)