### PR TITLE
fix(skills,docs): quote SKILL.md frontmatter and align README command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ ai-toolkit/
     ├── create-tests.md     # Create the first meaningful tests
     ├── update-tests.md     # Improve an existing test suite
     ├── run-test-plan.md    # Execute a reviewed validation plan
+    ├── test-pr.md          # Manual PR testing via Playwright browser
     ├── fix-ci.md           # Diagnose and safely fix CI failures
     ├── review-code.md      # Local review + autofix loop
     ├── review-pr.md        # Review GitHub PRs
     ├── address-feedback.md # Address PR feedback
-    ├── cherry-pick.md      # Cross-branch work
     ├── learn.md                 # Memory management — add, list, review, prune, propose rules
     ├── create-pr.md             # Generate PR title + description from diff/commits
     ├── review-code-adversarial.md # Red-team review for security and edge cases
@@ -130,7 +130,10 @@ ai-toolkit/
     ├── verify.md                # Run tests on changed files
     ├── review-plan.md           # One-off plan review with iteration
     ├── audit-agent-setup.md     # Audit commands, skills, rules, and agent docs
-    ├── archive-project-file.md  # Archive completed work
+    ├── complete-project.md      # Project capstone summary
+    ├── metrics.md               # Workflow metrics summary
+    ├── show-cost.md             # Token usage and cost summary
+    ├── optimize-cost.md         # Usage pattern analysis and recommendations
     └── toolkit-doctor.md        # Structural health check
 ```
 
@@ -149,6 +152,7 @@ ai-toolkit/
 | `/create-tests` | Standalone test-only workflow for creating the first meaningful tests in an area |
 | `/update-tests` | End-to-end workflow for improving an existing suite, reviewing it, and auto-committing when ready |
 | `/run-test-plan` | Standalone validation workflow that derives or reviews a test plan, executes it, and summarizes findings |
+| `/test-pr` | Manual PR testing via Playwright browser against a running local app |
 | `/fix-ci` | Diagnose CI failures, apply safe fixes, and stop before commit |
 | `/review-code` | Adaptive team review: code quality + architecture + test check + Codex second opinion |
 | `/review-code-adversarial` | Dual-model red-team (Claude + Codex in parallel) |
@@ -160,14 +164,22 @@ ai-toolkit/
 |---------|---------|
 | `/review-pr` | Adaptive team PR review: patterns, tests, architecture, RCA, auto-approve |
 | `/address-feedback` | Investigate PR comments, fix valid items, post replies |
-| `/cherry-pick` | Plan, order, and safely apply one or more cross-branch cherry-picks |
+| `/cherry-pick` | Plan, order, and safely apply one or more cross-branch cherry-picks (skill — also auto-triggers on natural-language requests) |
 | `/create-pr` | Generate PR title + description from diff, commits, and PROJECT.md |
 
 ### Project State
 | Command | Purpose |
 |---------|---------|
 | `/checkpoint` | Save workflow state to PROJECT.md (also for quick progress logs and full save-and-clear) |
-| `/archive-project-file` | Move completed phases to PROJECT_ARCHIVE.md |
+| `/complete-project` | Generate a project capstone summary when work wraps up |
+| `/archive-project-file` | Move completed phases to PROJECT_ARCHIVE.md (skill — also auto-triggers when archive intent is detected) |
+
+### Cost & Metrics
+| Command | Purpose |
+|---------|---------|
+| `/show-cost` | Token usage and cost summary for the current session |
+| `/optimize-cost` | Usage pattern analysis and cost-reduction recommendations |
+| `/metrics` | Aggregate workflow metrics from `.claude/metrics.jsonl` |
 
 ### Learning & Memory
 | Command | Purpose |

--- a/skills/cherry-pick/SKILL.md
+++ b/skills/cherry-pick/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cherry-pick
 description: Use when the user asks to cherry-pick, backport, port a fix, or apply commits/PRs onto another branch. Covers safety gates, scope-leak detection, adaptation, and per-change validation. Do NOT use for ordinary same-branch bug fixes, broad refactors, dependency upgrades, or behavior-changing rewrites without an explicit cross-branch move.
-argument-hint: [pr-url | sha...] [--target branch] [--force] [--plan-only]
+argument-hint: "[pr-url | sha...] [--target branch] [--force] [--plan-only]"
 allowed-tools: Bash(git *) Bash(gh *) Read Grep Glob Edit
 ---
 

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-review
-description: Use when critiquing a technical plan before implementation: architecture, backend, frontend, or implementation feasibility lenses. Do NOT use for reviewing shipped code, product briefs, test files, or post-implementation diffs.
+description: "Use when critiquing a technical plan before implementation: architecture, backend, frontend, or implementation feasibility lenses. Do NOT use for reviewing shipped code, product briefs, test files, or post-implementation diffs."
 user-invocable: false
 disable-model-invocation: true
 ---

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm
-description: Use for product scoping before technical planning: feature briefs, acceptance criteria, milestones, brief review, or epic decomposition. Do NOT use for technical implementation plans, code changes, code review, or test execution.
+description: "Use for product scoping before technical planning: feature briefs, acceptance criteria, milestones, brief review, or epic decomposition. Do NOT use for technical implementation plans, code changes, code review, or test execution."
 user-invocable: false
 disable-model-invocation: true
 ---

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preflight
-description: Use before work that needs a ready worktree or runnable app: dependency/env checks, build artifacts, Docker/service readiness, seed data, and feature flags. Do NOT use for writing tests, implementing code, or validating product behavior after the environment is ready.
+description: "Use before work that needs a ready worktree or runnable app: dependency/env checks, build artifacts, Docker/service readiness, seed data, and feature flags. Do NOT use for writing tests, implementing code, or validating product behavior after the environment is ready."
 user-invocable: false
 disable-model-invocation: true
 ---

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Use for reviewing actual code diffs: dispatching code-review lenses, code-quality checks, and adversarial review. Do NOT use for technical plan critique, product brief review, QA scenario design, or writing the fix.
+description: "Use for reviewing actual code diffs: dispatching code-review lenses, code-quality checks, and adversarial review. Do NOT use for technical plan critique, product brief review, QA scenario design, or writing the fix."
 user-invocable: false
 disable-model-invocation: true
 ---

--- a/skills/shortcut/SKILL.md
+++ b/skills/shortcut/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shortcut
-description: Use when a workflow needs Shortcut story, epic, iteration, or report operations through the Shortcut REST API: fetching records, parsing story fields, uploading evidence, posting comments, or linking PRs. Do NOT use for GitHub-only issue/PR work, local QA execution, or generic HTTP API calls unrelated to Shortcut.
+description: "Use when a workflow needs Shortcut story, epic, iteration, or report operations through the Shortcut REST API: fetching records, parsing story fields, uploading evidence, posting comments, or linking PRs. Do NOT use for GitHub-only issue/PR work, local QA execution, or generic HTTP API calls unrelated to Shortcut."
 user-invocable: false
 disable-model-invocation: true
 ---

--- a/skills/superset-local/SKILL.md
+++ b/skills/superset-local/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: superset-local
-description: Use for Superset-specific local development stack work: starting the Docker light stack, detecting the frontend port, applying known Superset proxy fixes, or running Superset Playwright E2E tests locally. Do NOT use for non-Superset apps, generic preflight checks, or QA scenario design.
+description: "Use for Superset-specific local development stack work: starting the Docker light stack, detecting the frontend port, applying known Superset proxy fixes, or running Superset Playwright E2E tests locally. Do NOT use for non-Superset apps, generic preflight checks, or QA scenario design."
 user-invocable: false
 disable-model-invocation: true
 ---

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing
-description: Use for HOW to test: creating or updating automated test suites, reviewing test code quality, and reviewing test-plan adequacy. Do NOT use for QA scenario discovery, manual product validation, bug triage, or general code review.
+description: "Use for HOW to test: creating or updating automated test suites, reviewing test code quality, and reviewing test-plan adequacy. Do NOT use for QA scenario discovery, manual product validation, bug triage, or general code review."
 user-invocable: false
 disable-model-invocation: true
 ---

--- a/skills/workstreams/SKILL.md
+++ b/skills/workstreams/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workstreams
-description: Use after parallel implementation subagents finish and their worktree results need fan-in: collect handoffs, update slice status, merge branches in dependency order, and surface failed or conflicting slices. Do NOT use for planning slices, implementing code, reviewing code, or running tests before handoff.
+description: "Use after parallel implementation subagents finish and their worktree results need fan-in: collect handoffs, update slice status, merge branches in dependency order, and surface failed or conflicting slices. Do NOT use for planning slices, implementing code, reviewing code, or running tests before handoff."
 user-invocable: false
 disable-model-invocation: true
 ---


### PR DESCRIPTION
## Summary
- Quote `description` (8 skills) and `argument-hint` (cherry-pick) in SKILL.md frontmatter so the files parse under strict YAML. Claude Code's lenient loader accepted the unquoted colons, but external YAML parsers (CI, editors, lint tools) flagged them.
- Align README with the actual `commands/` tree: add the five missing entries (`test-pr`, `complete-project`, `metrics`, `show-cost`, `optimize-cost`) and drop the obsolete `cherry-pick.md` / `archive-project-file.md` entries (they moved to `skills/` in #32).
- Annotate the slash-command tables so it's clear that `/cherry-pick` and `/archive-project-file` are now skill-backed — still invocable as slash input, and they also auto-trigger from natural-language intent.

## Test plan
- [ ] `python3 -c "import yaml; yaml.safe_load(open('skills/cherry-pick/SKILL.md').read().split('---')[1])"` succeeds for each of the 9 fixed SKILL.md files
- [ ] `/toolkit-doctor` reports no new DRIFT for commands/skills inventory
- [ ] Spot-check that `/cherry-pick` and `/archive-project-file` still invoke their respective skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)