### PR TITLE
fix(skills): tighten cherry-pick scope-leak enforcement and clean up checkpoint/QA reporting

### DIFF
--- a/commands/address-feedback.md
+++ b/commands/address-feedback.md
@@ -178,18 +178,6 @@ PR #[number] — [N] fixed, [N] skipped, [N] discussed
 - [ ] Review Gate block emitted (after fixes, unless skipped per skip rule)
 - [ ] Summary emitted
 
-## Continuation Checkpoint
-
-Phases: gather / complexity-gate / investigate / triage / fix / review / draft / post / summarize
-
-State:
-- PR: [number] — [title]
-- Complexity: [trivial / standard]
-- Triage: [N] fix, [N] skip, [N] discuss
-- Fixes committed: [yes / no / partial]
-- Review: [clean / blocked / pending]
-- Posted: [yes / no / pending]
-
 ## Notes
 - Always investigate before triaging — read the actual code
 - TDD for behavioral changes, direct fix for cosmetic/pattern-following

--- a/commands/checkpoint.md
+++ b/commands/checkpoint.md
@@ -48,6 +48,8 @@ The three templates below are the canonical format — other commands and report
 
 The checkpoint header is intentionally light — workflow metadata only. State details live in Current Status; resume specifics live in the Progress Update message. Do not duplicate across sections.
 
+Start from the generic shape:
+
 ```markdown
 ## Continuation Checkpoint — [ISO timestamp]
 ### Workflow
@@ -55,6 +57,8 @@ The checkpoint header is intentionally light — workflow metadata only. State d
 - Phase: [phase]
 - Active plan: PLAN.md | none
 ```
+
+If the detected top-level command has a per-command extension at `skills/reporting/templates/<command>-checkpoint.md` (e.g. `fix-bug-checkpoint.md`, `create-feature-checkpoint.md`), append the additional Workflow fields that template specifies. The per-command templates own only the extra fields — they do not redefine the generic header. For ad-hoc work or commands without an extension, write the generic shape alone.
 
 **b. `## Current Status` — refresh in place:**
 

--- a/commands/create-tests.md
+++ b/commands/create-tests.md
@@ -63,16 +63,6 @@
    - [Ready for manual commit / needs more work]
    ```
 
-## Continuation Checkpoint
-
-Phases: scope / review-tests / write-tests / verify / review / summarize
-
-State:
-- Current scope: <what is being tested>
-- Review status: <clean / blocked / pending>
-- Tests added so far: <files or none>
-- Verification status: <passed / partial / blocked>
-
 ## Notes
 - `/create-tests` is a test-only command, not the normal entrypoint for feature or bug workflows
 - Favor the smallest set of high-signal tests over broad test quantity

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -161,10 +161,6 @@ Lead with whether the user's reported symptom is fixed — if the user gave you 
 - `gate_decisions`: `{ complexity: <step 1>, existing_fix: <FIXED_UPSTREAM | FIX_PENDING_PR | UNFIXED | SKIPPED>, review: <step 5> }`
 - `models_used`: subagent model invocation counts
 
-## Continuation Checkpoint
-
-Use the template at [skills/reporting/templates/fix-bug-checkpoint.md](../skills/reporting/templates/fix-bug-checkpoint.md).
-
 ## Cross-Repo Bugs
 
 When the symptom is in repo A (e.g., CI failure in a downstream fork) but the fix goes in repo B (e.g., upstream):

--- a/commands/fix-ci.md
+++ b/commands/fix-ci.md
@@ -256,24 +256,6 @@
 
 Keep the updates compact, but do not defer all state changes to the end of the workflow.
 
-## Continuation Checkpoint
-
-```markdown
-## Continuation Checkpoint — [timestamp]
-### Workflow
-- Top-level command: /fix-ci <arguments>
-- Phase: gather-logs / classify / ownership-check / complexity-gate / rca / gate / apply / verify / review / summarize
-- Resume target: <run id, artifact, failing job, or changed file set>
-- Completed items: <finished phases or already-fixed failures>
-### State
-- Complexity: <trivial / moderate / standard>
-- Failure summary: <current best classification>
-- Gate result: <proceed / approval / stop>
-- Review status: <clean / blocked / pending>
-- Files changed so far: <files or none>
-- Pending blockers or decisions: <if any>
-```
-
 ## Notes
 - Always read the actual failing log output — don't guess from job names alone
 - Auto-fixing is a phase, not the contract; trivial fixes with STRONG verification commit and push automatically — standard-path and weak-verification fixes still stop before commit

--- a/commands/review-plan.md
+++ b/commands/review-plan.md
@@ -111,22 +111,6 @@ Write final review scores to PROJECT.md:
 - After review iterations complete: write final scores
 - If revisions were made: the plan sections in PROJECT.md are updated as part of each revision
 
-## Continuation Checkpoint
-
-```markdown
-## Continuation Checkpoint — [timestamp]
-### Workflow
-- Top-level command: /review-plan [flags]
-- Phase: read-plan / detect-reviewers / review-iterations / cold-read / update / summarize
-- Resume target: [current reviewer or iteration round]
-- Completed items: [reviewers already at 8/10]
-### State
-- Reviewers selected: [list]
-- Current scores: [reviewer: score, ...]
-- Cold read: [go / no-go / pending]
-- Revisions made: [count]
-```
-
 ## Notes
 - Standalone command — `/create-feature` step 4 does the same work inline, but this is for one-off use
 - Does not create or implement the plan — only reviews an existing one

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -266,25 +266,6 @@ After all subagents complete, aggregate:
 - [ ] Team selection shown in summary
 - [ ] Summary emitted
 
-## Continuation Checkpoint
-
-**Single-PR phases**: gather / complexity-gate / understand-problem / detect-team / launch-review / pattern-analysis / scoring / gate / post / summarize
-
-**Batch phases**: gather-list / dispatch-reviews / collect-results / batch-summary
-
-State (single PR):
-- PR: [number] — [title]
-- Complexity: [trivial / standard]
-- Team: [list of selected reviewers]
-- Scores: [component: score, ...]
-- Recommendation: [approve / request-changes / comment / pending]
-- Posted: [yes / no / pending]
-
-State (batch):
-- Mode: batch
-- PRs: [N total, N complete, N failed]
-- Recommendations: [N approve, N request-changes, N comment]
-
 ## Notes
 - Accepts single PRs or batches — batch detection is automatic. Use `--all-open` to review every open PR in the repo.
 - Batch mode defaults to `--auto` (posts reviews without confirmation). No worktrees needed — reviews are read-only.

--- a/commands/run-test-plan.md
+++ b/commands/run-test-plan.md
@@ -107,16 +107,6 @@
    - [Manual next steps only]
    ```
 
-## Continuation Checkpoint
-
-Phases: resolve-plan / review-plan / execute / capture-evidence / summarize
-
-State:
-- Plan score: <score or blocked>
-- Execution status: <not started / partial / complete>
-- Evidence status: <captured / none / pending>
-- Blockers or unclear items: <if any>
-
 ## Notes
 - `/run-test-plan` is validation-only in v1
 - Prefer a small runnable matrix over a broad exploratory sweep

--- a/commands/test-pr.md
+++ b/commands/test-pr.md
@@ -112,6 +112,14 @@ Do not run scenarios in parallel — sequential execution keeps evidence clean.
 
 ### 7. Report
 
+The template below is for **in-terminal output only**.
+
+If the user asks to post results to a Shortcut story, GitHub PR/issue comment, or any other shared external destination, do not adapt this template. Instead:
+- Read [skills/qa/references/write-report.md](../skills/qa/references/write-report.md) for canonical body shape (single-flow vs multi-scenario), tone (narrative not technical), and evidence rules. Load the matching template / example from `qa/references/write-report/` only when actually drafting.
+- Read the destination-specific reference for upload + post mechanics: [skills/shortcut/references/report.md](../skills/shortcut/references/report.md) for Shortcut, or the equivalent for other destinations.
+
+The terminal template below specifies a tabular grid that's appropriate for in-conversation summaries only — never paste it into an external comment.
+
 ```markdown
 ## Test-PR Complete
 
@@ -148,17 +156,6 @@ Impact: CORE / STANDARD / PERIPHERAL
 [Failures:] Feed findings back to the PR author — specific failures listed above.
 [Blocked:] Resolve blockers above and re-run `/test-pr <number>`.
 ```
-
-## Continuation Checkpoint
-
-Phases: resolve-pr / detect-url / assess-impact / derive-scenarios / confirm-scenarios / execute / report
-
-State:
-- PR: <number> — <title>
-- App URL: <url or pending>
-- Impact: <CORE / STANDARD / PERIPHERAL>
-- Scenarios: <N total, N complete, N remaining>
-- Results so far: <N pass, N fail, N blocked>
 
 ## Notes
 - **This command tests what is currently running** — make sure the right branch is checked out and the app is up before running

--- a/commands/update-tests.md
+++ b/commands/update-tests.md
@@ -118,17 +118,6 @@
    - [Created `test:` commit / no commit and why]
    ```
 
-## Continuation Checkpoint
-
-Phases: scope / gap-analysis / update-tests / verify / review / commit / summarize
-
-State:
-- Existing suite status: <found / insufficient / none>
-- Review status: <clean / blocked / pending>
-- Files changed so far: <files or none>
-- Verification status: <passed / partial / blocked>
-- Pending blockers or follow-up gaps: <if any>
-
 ## Notes
 - `/update-tests` is the public workflow for existing-suite maintenance
 - Favor replacing low-signal tests over adding redundant ones

--- a/skills/cherry-pick/SKILL.md
+++ b/skills/cherry-pick/SKILL.md
@@ -85,21 +85,26 @@ If a trivial change unexpectedly hits conflicts, escalate to adapt — the gate 
 
 → Conflict classification, scope leak detection during resolution, escalation triggers: [references/adapt.md](references/adapt.md)
 
-### 7. Validate (model from gate)
+### 7. Validate
 
-**Invariant: the agent that applied must not validate its own work.** Self-validation misses scope leak — the failure in gotchas.md (#38809) was caught exactly because validation happened in a fresh context. Use a subagent, a new session, or any mechanism that gives validation a clean view — the *how* is flexible, the *fresh context* is not.
+Two distinct jobs, run on different threads:
 
-The diff audit is **mandatory for every cherry-pick, including clean applies**. Clean applies are the highest-risk vector for scope leak.
+**7a. Scope-leak audit — subagent, mandatory, every cherry, no exceptions.**
 
-```bash
-${CLAUDE_SKILL_DIR}/scripts/scope-audit.sh <source-commit>
-```
+Post-apply, spawn a subagent (model from gate: Sonnet for trivial, Opus for non-trivial). Its only job is leak detection. Single rule: every cherry, every time, including clean applies — clean applies are the highest-risk vector for scope leak.
 
-This runs the mechanical pre-check (file list comparison, line count divergence). Then do the LLM hunk-level audit on anything flagged.
+The subagent must:
+1. Run `${CLAUDE_SKILL_DIR}/scripts/scope-audit.sh <source-commit>` and capture the literal output.
+2. Run the LLM hunk-level audit comparing source diff vs cherry-pick result diff.
+3. Return a structured report containing the literal `scope-audit.sh` output, per-hunk verdict, and a clear `LEAK / CLEAN / ESCALATE` recommendation.
 
-→ Full procedure (LLM audit, validation order, status labels, dependency manifest rule): [references/validate.md](references/validate.md)
+The orchestrator may not mark a cherry `Applied` without this report. If the subagent finds leaks, revert leaked hunks and amend on the main thread, then re-spawn the subagent on the amended commit.
 
-If audit finds leaks, revert leaked hunks and amend before pushing.
+**7b. Correctness validation — main thread.**
+
+Conflict-marker scan, build, type-check, targeted tests. Build failures are loud and don't need a fresh context — the main thread handles them.
+
+→ Full procedure (subagent contract, LLM audit, validation order, status labels, dependency manifest rule): [references/validate.md](references/validate.md)
 
 **Push after each successful cherry-pick** so CI runs against the change:
 ```bash
@@ -126,7 +131,7 @@ When multiple PRs/SHAs are provided, the main agent acts as a **thin orchestrato
 
 Use the format in [examples/final-report.md](examples/final-report.md). Lead with the ticket outcome (what the user cares about), then the execution table, then actionable residuals.
 
-The full 12-column execution table format is in [examples/execution-table.md](examples/execution-table.md). The compact table replaces it only in the final report.
+The full 13-column execution table format is in [examples/execution-table.md](examples/execution-table.md). The compact table replaces it only in the final report.
 
 **Record metrics**: include `metrics-emit` context with:
 - `command`: `cherry-pick`

--- a/skills/cherry-pick/SKILL.md
+++ b/skills/cherry-pick/SKILL.md
@@ -138,7 +138,8 @@ The full 13-column execution table format is in [examples/execution-table.md](ex
 - `complexity`: from gate (`trivial` / `non-trivial`); use `standard` for batch
 - `status`: aggregate result (`clean` if all Applied, `blocked` if any Blocked/Rejected requiring intervention, etc.)
 - `rounds`: total plan-review iterations across all cherries (0 if all clean)
-- `gate_decisions`: `{ verdict: PROCEED | REJECT | FORCE-PROCEED, scope_audit: <CLEAN | LEAKED>, batch_size: <N> }`
+- `gate_decisions`: `{ verdict: PROCEED | REJECT | FORCE-PROCEED, batch_size: <N> }`
+- `scope_audit`: per-cherry verdicts from the 7a subagent — `{ clean: <N>, leaked_reverted: <N>, escalated: <N> }`. Single cherry: one of `CLEAN | LEAKED-REVERTED | ESCALATED`.
 - `models_used`: subagent model invocation counts
 
 ## Continuation Checkpoint

--- a/skills/cherry-pick/examples/execution-table.md
+++ b/skills/cherry-pick/examples/execution-table.md
@@ -1,12 +1,12 @@
 # Execution Table Format (Full)
 
-The 12-column table tracks each cherry through every phase. Produced by the plan phase, updated by apply/adapt/validate, preserved through the final report as detailed notes.
+The 13-column table tracks each cherry through every phase. Produced by the plan phase, updated by apply/adapt/validate, preserved through the final report as detailed notes.
 
 ```markdown
-| # | SHA | PR | Description | Depends On | Risk | Confidence | Decision | Status | Adaptation | Validation | Notes |
-|---|-----|----|-------------|------------|------|------------|----------|--------|------------|------------|-------|
-| 1 | `<sha>` | #123 | <summary> | — | LOW | 9/10 | Auto | Applied | None | Tested | Clean apply |
-| 2 | `<sha>` | #124 | <summary> | #123 | MED | 7/10 | Approval | Partial | Medium | Checked | 2 of 3 sub-fixes applied |
+| # | SHA | PR | Description | Depends On | Risk | Confidence | Decision | Status | Adaptation | Scope Audit | Validation | Notes |
+|---|-----|----|-------------|------------|------|------------|----------|--------|------------|-------------|------------|-------|
+| 1 | `<sha>` | #123 | <summary> | — | LOW | 9/10 | Auto | Applied | None | CLEAN | Tested | Clean apply |
+| 2 | `<sha>` | #124 | <summary> | #123 | MED | 7/10 | Approval | Partial | Medium | CLEAN (1 hunk reverted) | Checked | 2 of 3 sub-fixes applied |
 ```
 
 ## Field Meanings
@@ -23,8 +23,13 @@ The 12-column table tracks each cherry through every phase. Produced by the plan
 | `Decision` | `Auto`, `Approval`, `Escalate` | gate |
 | `Status` | `Planned`, `Applied`, `Partial`, `Blocked`, `Rejected`, `Skipped` | apply/adapt |
 | `Adaptation` | `None`, `Minor`, `Medium`, `High` | adapt (see plan.md for definitions) |
-| `Validation` | `Not run`, `Tested`, `Checked`, `Build-only`, `Structural` | validate |
+| `Scope Audit` | `CLEAN`, `CLEAN (N hunks reverted)`, `ESCALATE` | scope-leak subagent (7a) |
+| `Validation` | `Not run`, `Tested`, `Checked`, `Build-only`, `Structural` | validate (7b, main thread) |
 | `Notes` | Short freeform | any phase |
+
+## Scope Audit Field
+
+**Mandatory.** A cherry cannot be marked `Applied` (or `Partial`) without a `Scope Audit` value populated by the scope-leak subagent (see [../references/validate.md](../references/validate.md)). The literal `scope-audit.sh` output and per-hunk verdict belong in the detailed notes for any row whose audit was not pristine `CLEAN`.
 
 ## Status Semantics
 

--- a/skills/cherry-pick/examples/final-report.md
+++ b/skills/cherry-pick/examples/final-report.md
@@ -4,11 +4,12 @@ Use this format at the end of every cherry-pick (single or batch). Lead with the
 
 ## Rules
 
-- The compact 5-column table replaces the full 12-column execution table only in the final report. See [execution-table.md](execution-table.md) for the full table.
+- The compact 6-column table replaces the full 13-column execution table only in the final report. See [execution-table.md](execution-table.md) for the full table.
 - Add **Detailed Notes** for any row that is not `Applied` with `None` adaptation, plus any `Applied` row with notable adaptation.
 - Keep the dependency graph from the batch-sequence phase if inter-change dependencies were detected.
 - "What to do next" is actionable only — no recap of what just happened.
 - Lead with the ticket outcome. The user cares about "is the fix on the branch" more than about the process.
+- **Scope Audit field is mandatory** for any row not in `Rejected` or `Skipped` — its absence means the leak-detection subagent did not run, which blocks `Applied`/`Partial`/`Blocked` status.
 
 ## Template
 
@@ -20,11 +21,11 @@ Use this format at the end of every cherry-pick (single or batch). Lead with the
 [X of N applied, Y rejected, Z partial] -> <target branch>
 
 ### Results
-| SHA | PR | Status | Validation | Notes |
-|-----|----|--------|------------|-------|
-| `<sha>` | #123 | Applied | Tested | Clean apply |
-| `<sha>` | #124 | Partial | Checked | 5 of 7 sub-fixes applied; encoding fix dropped — see below |
-| `<sha>` | #125 | Rejected | — | Feature change, no --force |
+| SHA | PR | Status | Scope Audit | Validation | Notes |
+|-----|----|--------|-------------|------------|-------|
+| `<sha>` | #123 | Applied | CLEAN | Tested | Clean apply |
+| `<sha>` | #124 | Partial | CLEAN (1 hunk reverted) | Checked | 5 of 7 sub-fixes applied; encoding fix dropped — see below |
+| `<sha>` | #125 | Rejected | — | — | Feature change, no --force |
 
 ### Detailed Notes
 #### `<sha>` — <summary>

--- a/skills/cherry-pick/references/validate.md
+++ b/skills/cherry-pick/references/validate.md
@@ -2,9 +2,12 @@
 
 Use after a cherry-pick applies cleanly or after conflict resolution completes.
 
-**Always runs as a subagent** — the thread that applied must not validate its own work.
+Validate is two distinct jobs:
 
-**Model selection**: set by the gate (Sonnet for trivial, Opus for non-trivial). The caller spawns this subagent with the correct model.
+- **Scope-leak audit (7a)** — runs as a subagent, mandatory for every cherry, no exceptions. Catches the silent failure mode that build/test cannot catch.
+- **Correctness validation (7b)** — runs on the main thread. Build/type-check/tests fail loudly when the cherry is broken; no fresh context required.
+
+**Model selection** for the scope-leak subagent: set by the gate (Sonnet for trivial, Opus for non-trivial). The caller spawns the subagent with the correct model.
 
 ## Goal
 
@@ -12,21 +15,25 @@ Prove that the moved change is integrated cleanly, contains only the intended ch
 
 Consume risk signals from investigate and adaptation signals from adapt. Do not re-litigate whether the cherry-pick should have happened.
 
-## Parallel Work
+## Subagent Contract — Scope-Leak Audit (7a)
 
-When project tooling allows it safely, run these in parallel:
+**One job, one rule: every cherry-pick gets a fresh subagent for leak detection. No tiers, no carve-outs, no "trivial" skip.** Clean applies are the highest-risk vector — they look fine and ship leaked code from adjacent commits (see [../gotchas.md](../gotchas.md) #1).
 
-1. Conflict-marker scan
-2. Fast build or type-check
-3. Targeted tests for the touched area
+**Subagent inputs:** source commit SHA, target branch HEAD SHA after apply, summary of any adapt-phase changes.
 
-Avoid parallel validation when the project's test/build tooling fights for the same generated outputs or shared local environment.
+**Subagent must produce** (orchestrator refuses `Applied` status without all three):
 
-## Diff Audit (Scope Leak Check) — MANDATORY
+1. Literal stdout of `${CLAUDE_SKILL_DIR}/scripts/scope-audit.sh <source-commit>` — pasted verbatim, not summarized.
+2. Per-hunk audit verdict from Step 2 below — explicit list of extra hunks (or "none") with origin classification for each.
+3. Final recommendation: `CLEAN` / `LEAK — revert <hunks>` / `ESCALATE — <reason>`.
 
-Run this **before** build/test validation. A clean build doesn't catch unrelated changes that happen to compile.
+If the subagent returns `LEAK`, the main thread reverts the named hunks, amends, and re-spawns the subagent on the amended commit. Loop until `CLEAN` or `ESCALATE`.
 
-**Mandatory for every cherry-pick, including clean applies with zero conflicts.** This intentionally re-checks scope even when adapt already ran its own leak detection — defense in depth. Do not skip because adapt "already checked." See [../gotchas.md](../gotchas.md) for the scope-leak failure mode.
+The subagent does **not** run build/test. Correctness is the main thread's job (7b).
+
+## Diff Audit Procedure (executed by the subagent)
+
+Run **before** build/test validation. A clean build doesn't catch unrelated changes that happen to compile.
 
 ### Step 1: Mechanical Pre-Check
 
@@ -44,7 +51,7 @@ This produces a mechanical comparison (file list, line counts) — no LLM judgme
 **Interpretation:**
 - **Extra files found** → scope leak until proven otherwise. Investigate each in Step 2.
 - **Line count differs by >20% for a shared file** → flag for hunk-level investigation.
-- **Both checks clean** → still run Step 2, but with higher confidence.
+- **Both checks clean** → Step 2 is still mandatory. Mechanical CLEAN does NOT permit skipping the hunk audit — small leaks inside heavily-touched shared files pass under the 20% threshold. The mechanical pre-check only adjusts confidence; it never removes the hunk audit requirement.
 
 ### Step 2: LLM Hunk-Level Audit
 
@@ -79,7 +86,9 @@ Verdict: [clean / leaked — reverted / leaked — kept with justification]
 
 If the audit finds leaks, revert them before proceeding to build/test validation. If a leaked change appears to be a required prerequisite, escalate to the user rather than silently keeping it.
 
-## Validation Order
+## Correctness Validation — Main Thread (7b)
+
+Runs only after the scope-leak subagent returns `CLEAN`. Build/test failures are loud and self-describing; no fresh context required.
 
 At minimum:
 1. Confirm no conflict markers.

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -23,6 +23,7 @@ Umbrella skill for repo-standard QA phases. The orchestrator picks the relevant 
 | Expand scenarios | After fix is known: identify smallest extra checks for regression protection | [references/expand-scenarios.md](references/expand-scenarios.md) |
 | Execute use cases | Run scenarios against a real environment with evidence capture | [references/execute-use-cases.md](references/execute-use-cases.md) |
 | File bug | Strong failure signal needs a clean handoff (Shortcut posting included) | [references/file-bug.md](references/file-bug.md) |
+| Write report | QA results need to land on a Shortcut/PR/Slack/email destination — canonical body shape and tone | [references/write-report.md](references/write-report.md) |
 
 ## Invocation Patterns
 

--- a/skills/qa/references/write-report.md
+++ b/skills/qa/references/write-report.md
@@ -1,0 +1,67 @@
+---
+model: sonnet
+---
+
+# Write QA Report
+
+Canonical rules for QA verification reports posted to **any** shared destination — Shortcut comments, GitHub PR/issue comments, Slack threads, email summaries. Destination-specific mechanics (file upload API, comment endpoint, attachments rail) live in the destination's own reference; this file owns the body content rules.
+
+## When to Use
+
+After running QA validation, fix verification, or PR smoke tests, when results need to land on a ticket, PR, or shared channel that *other people* will read.
+
+Use *instead of* terminal-only output formats (e.g. `/test-pr` Step 7 grid, `validate-fix.md` bullet block) when the destination is external.
+
+## Pick the Shape
+
+**Single-flow report** — one bug, one repro path, even with 2–3 related checks within that flow. Use when the whole verification is one continuous user journey.
+
+**Multi-scenario report** — distinct viewports, roles, configs, browsers, feature-flag states, or independent flows. Per-scenario blocks each carry their own steps + result + inline screenshot.
+
+When in doubt, ask: *if a reviewer wanted to re-run just one of these checks, would they need different setup?* If yes → multi-scenario.
+
+Skeletons (load only when drafting):
+- [templates/single-flow.md](write-report/templates/single-flow.md)
+- [templates/multi-scenario.md](write-report/templates/multi-scenario.md)
+
+Worked examples (load for tone match):
+- [examples/single-flow-sc97462.md](write-report/examples/single-flow-sc97462.md) — bug fix verification on one flow
+- [examples/multi-scenario-sc101082.md](write-report/examples/multi-scenario-sc101082.md) — viewport-bug verification across four sizes
+
+## Tone — Narrative, Not Technical
+
+Write like a non-engineer QA reviewer. They care whether the thing looks and works right, not how. The reader should be able to confirm the verdict from the narrative alone, without opening the video.
+
+**Do say:**
+- "the Apply button stayed visible"
+- "the dropdown fit on screen with no overlap"
+- "after clicking Save, the row appeared in the list"
+- "the chart rendered the same labels as before the change"
+- "no console errors fired during the flow" *(only if you actually checked)*
+
+**Don't say:**
+- DOM class names or selectors: `ant-picker-dropdown`, `.MuiButton-root`, `data-test="..."`
+- Pixel-precise measurements: `bottom=722.66 px`, `top=158`
+- CSS property names or computed-style internals
+- Fix recommendations: "the height clamp should also bound the outer wrapper" — that's an engineering note, not a QA observation. File it separately.
+- Speculation about cause or impact beyond what evidence shows
+
+If you noticed something engineering-relevant during testing, leave it out of the comment and surface it in the in-conversation handoff or a separate engineering note.
+
+## Verdict First, Then Details
+
+Lead the **Result** with a one-sentence verdict (PASS / FAIL / PARTIAL) and the headline finding. Follow-up sentences expand: what worked, what didn't, what you checked. A reviewer should be able to stop reading after the first sentence and still know whether to merge.
+
+## Evidence
+
+- **Video** — record the *full* flow (login → setup → all scenarios). One recording covering everything is more useful than one per scenario.
+- **Screenshots** — one per scenario in multi-scenario reports, embedded inline at the verification point. Skip in single-flow reports unless the video is too long to scrub.
+- **Naming** — use `<destination-id>-<short-label>.<ext>`, e.g. `sc-101082-1280x720-popover.png`, `pr-3903-readonly-role.png`. Makes attachments self-describing in the destination's file rail.
+- **Upload mechanism** — see the destination's reporting reference (e.g. `skills/shortcut/references/report.md` for Shortcut's `/files` endpoint). Capture the returned hosted URL and embed inline.
+
+## Anti-Patterns
+
+- Pasting a tabular pass/fail grid (the `/test-pr` Step 7 format) as a Shortcut/GitHub comment — that grid is for terminal output only.
+- One mashed-up repro list covering four different viewports, with all evidence dumped at the bottom — use multi-scenario shape instead.
+- Engineering postmortem prose ("the issue is that `calculatePopupAlign` doesn't clamp the dropdown wrapper") — keep cause analysis out of the comment; file it separately.
+- "Tested on staging" with no URL/build/branch — make the environment line copy-pasteable so a reader can re-run.

--- a/skills/qa/references/write-report/examples/multi-scenario-sc101082.md
+++ b/skills/qa/references/write-report/examples/multi-scenario-sc101082.md
@@ -1,0 +1,51 @@
+# Example — Multi-Scenario QA Report (sc-101082)
+
+Real Preset QA verification posted to https://app.shortcut.com/preset/story/101082#activity-105068. Use as a tone reference for reports covering several distinct viewports / roles / configs: per-scenario block with its own steps + result + inline screenshot, one full-flow video at the end.
+
+```markdown
+## QA Verification — PARTIAL ⚠️
+
+**Tested on**: https://0de345d5.us1a.app-stg.preset.io (PR #3903 branch `fix-time-range-zoom`)
+**Date**: 2026-04-28
+**Tester**: Playwright automation
+
+### Scenario 1 — small viewport (1280×720), the resolution from the ticket
+1. Logged in, opened the Sales Dashboard.
+2. Clicked the Time Range filter trigger in the left filter panel.
+
+**Result:** The Apply and Cancel buttons are now mostly visible — labels readable, buttons clickable — but their bottom border still sits a few pixels below the screen edge. Clear improvement on the original report, but the buttons aren't yet fully on screen at this viewport.
+
+![Scenario 1 — 1280×720 popover](https://media.app.shortcut.com/.../scenario-1-1280x720.png)
+
+### Scenario 2 — normal viewport (1280×1000)
+1. Resized the window taller, reopened the same filter.
+
+**Result:** Popover fits entirely inside the viewport. Apply and Cancel fully visible. No regression on the happy path.
+
+![Scenario 2 — 1280×1000 popover](https://media.app.shortcut.com/.../scenario-2-1280x1000.png)
+
+### Scenario 3 — tab switching at 1280×720
+1. Reopened the popover at 1280×720.
+2. Switched to the **Custom** tab, then back to **Basic**.
+
+**Result:** Footer stays pinned in place; tab content swaps cleanly. No content overflow inside the popover.
+
+![Scenario 3 — Custom tab at 1280×720](https://media.app.shortcut.com/.../scenario-3-custom-tab-1280x720.png)
+
+### Scenario 4 — extreme small viewport (1280×500)
+1. Resized to a deliberately short viewport, reopened the filter.
+
+**Result:** Same partial-clipping pattern as Scenario 1 — labels visible, button bottom clipped a few pixels.
+
+![Scenario 4 — 1280×500 popover](https://media.app.shortcut.com/.../scenario-4-1280x500.png)
+
+### Full-flow evidence:
+[sc-101082-time-range-popover.webm](https://media.app.shortcut.com/...) — login → dashboard → all four scenarios in one recording.
+```
+
+Why this works:
+- Each viewport is a separate scenario block — a reviewer can re-run just Scenario 4 without scrolling for context.
+- Per-scenario inline screenshot lands the visual evidence next to the prose that describes it.
+- The verdict on each scenario is a single sentence; no DOM internals or pixel math.
+- One full-flow video covers everything end-to-end — easier to scrub than four separate recordings.
+- Header verdict is **PARTIAL ⚠️** because Scenarios 1 and 4 fail; Scenarios 2 and 3 pass. The header reflects the worst result.

--- a/skills/qa/references/write-report/examples/single-flow-sc97462.md
+++ b/skills/qa/references/write-report/examples/single-flow-sc97462.md
@@ -1,0 +1,33 @@
+# Example — Single-Flow QA Report (sc-97462)
+
+Real Preset QA verification posted to https://app.shortcut.com/preset/story/97462. Use as a tone reference: narrative prose, verdict-first, two related checks labeled inline within one Result block, single video link.
+
+```markdown
+## QA Verification — PASS ✅
+
+**Tested on**: https://1656bd0b.us1a.app-stg.preset.io (staging 6.0.0.6rc1)
+**Date**: 2026-02-20
+**Tester**: Playwright automation (playwright-bot@testing.com)
+
+### Repro steps followed:
+1. Opened "World Bank's Data" dashboard → Explore view for "World's Pop Growth" chart
+2. Opened the ad-hoc filter popover and clicked "Time Range"
+3. Clicked "Start date" to open the time range picker modal
+4. Navigated to the "Custom" tab → "Relative Date/Time" option
+5. Selected all text in the numeric spinbutton (value "7") and pressed Backspace
+6. Typed "365" character by character with delays between each keystroke
+
+### Result:
+**Bug appears fixed.**
+- **Test 1 (delete value):** After selecting all and pressing Backspace, the field cleared to empty — it does NOT snap back to "1" as reported in the bug.
+- **Test 2 (type 365):** After typing "3", the field shows "3". After typing "6", it shows "36". After typing "5", it shows "365". All digits appear correctly without disappearing/reappearing.
+
+### Evidence:
+[sc-97462-relative-date-input-fix.webm](https://media.app.shortcut.com/...)
+```
+
+Why this works:
+- The repro is one continuous user flow that exercises both bug variants.
+- Verdict ("Bug appears fixed") lands in the first line of Result; details follow as labeled bullets.
+- No DOM jargon, no pixel measurements, no fix proposals.
+- One video covers the whole flow — no per-bullet screenshots needed.

--- a/skills/qa/references/write-report/templates/multi-scenario.md
+++ b/skills/qa/references/write-report/templates/multi-scenario.md
@@ -1,0 +1,35 @@
+# Multi-Scenario Template
+
+For distinct viewports, roles, configs, browsers, feature-flag states, or independent flows. See [../../write-report.md](../../write-report.md) for shape selection and tone rules.
+
+```markdown
+## QA Verification — PASS ✅ / FAIL ❌ / PARTIAL ⚠️
+
+**Tested on**: <environment URL or description> (<version/branch/build info>)
+**Date**: <YYYY-MM-DD>
+**Tester**: <who or what ran the test>
+
+### Scenario 1 — <short label, e.g. "Desktop 1440×900" or "Read-only role">
+1. <step>
+2. <step>
+
+**Result:** <one-sentence verdict + 1–2 sentences of narrative.>
+
+![Scenario 1 — <label>](<hosted PNG URL>)
+
+### Scenario 2 — <short label>
+1. <step>
+2. <step>
+
+**Result:** <one-sentence verdict + 1–2 sentences of narrative.>
+
+![Scenario 2 — <label>](<hosted PNG URL>)
+
+### Full-flow evidence:
+[<descriptive-filename.webm>](<hosted media URL>) — <one-line description of what the recording covers>
+```
+
+Notes:
+- Each scenario gets its own steps + result + inline screenshot, in that order.
+- One full-flow video at the end (not one per scenario) — the recording covers login + setup + all scenarios in sequence.
+- Scenario labels should be self-describing: viewport size, role name, browser, flag state — whatever distinguishes them.

--- a/skills/qa/references/write-report/templates/single-flow.md
+++ b/skills/qa/references/write-report/templates/single-flow.md
@@ -1,0 +1,24 @@
+# Single-Flow Template
+
+For one bug, one repro path. See [../../write-report.md](../../write-report.md) for shape selection and tone rules.
+
+```markdown
+## QA Verification — PASS ✅ / FAIL ❌ / PARTIAL ⚠️
+
+**Tested on**: <environment URL or description> (<version/branch/build info>)
+**Date**: <YYYY-MM-DD>
+**Tester**: <who or what ran the test>
+
+### Repro steps followed:
+1. <what you actually did, step by step>
+2. <be specific — name the dashboard, chart, page, action>
+3. <include what you looked for and how you verified>
+
+### Result:
+**<One-sentence verdict.>** <2–3 sentences of narrative explaining what you observed. What rendered, what didn't break, what you checked.>
+
+### Evidence:
+[<descriptive-filename.webm>](<hosted media URL>)
+```
+
+If the report has multiple related checks within the same flow, label them inline in the Result block (e.g. `**Test 1 (delete value):** ...`, `**Test 2 (type 365):** ...`) rather than splitting into separate sections.

--- a/skills/reporting/SKILL.md
+++ b/skills/reporting/SKILL.md
@@ -61,13 +61,13 @@ The command-specific sections in the middle vary; the lead, the "What to do next
 
 ## Continuation Checkpoint structure
 
-When a workflow pauses (cost/context threshold, user interrupt, blocker), it must emit a checkpoint that lets a future session resume from the exact state.
+`/checkpoint` is the single writer of `## Continuation Checkpoint` blocks in PROJECT.md. End-to-end commands do **not** define their own checkpoint sections — they rely on the user (or an internal context-management trigger) invoking `/checkpoint`, which autodetects the active top-level command and extends its generic header with per-command fields.
 
 ### Rules
 
 1. **Workflow identification first.** The top-level command, its arguments, and the current phase. Without this, resumption guesses.
-2. **Resume target second.** What artifact, file, ticket, or decision the next session should pick up at.
-3. **State fields are command-specific.** Each command lists only the state that matters for its workflow — scores, classifications, completed items.
+2. **Header stays light.** Workflow metadata only. Resume specifics belong in the `### [timestamp] — Progress Update` entry; state details belong in `## Current Status`. Do not duplicate across sections.
+3. **Per-command fields extend the Workflow block.** Each command's template adds extra Workflow lines (e.g., `Existing-fix status:` for `/fix-bug`); it does not introduce a separate `### State` section.
 4. **No procedural recap.** The checkpoint records *state*, not *steps taken*.
 5. **Timestamps in ISO format** so future sessions can compute staleness.
 
@@ -78,26 +78,22 @@ When a workflow pauses (cost/context threshold, user interrupt, blocker), it mus
 ### Workflow
 - Top-level command: /<command> <arguments>
 - Phase: <phase identifier>
-- Resume target: <what to pick up next>
-- Completed items: <finished phases or accepted decisions>
-
-### State
-- <command-specific state field>: <value>
-- <command-specific state field>: <value>
+- Active plan: PLAN.md | none
+- <per-command field>: <value>     # appended from skills/reporting/templates/<command>-checkpoint.md, if present
 ```
 
-The Workflow block is identical across commands. The State block is per-command.
+The first three Workflow lines are owned by `/checkpoint`. Per-command templates contribute only the additional lines.
 
 ## How to use
 
-End-to-end commands reference both this skill (for structural rules) and their specific template:
+End-to-end commands reference this skill for **summaries only**. Continuation Checkpoints are owned by `/checkpoint`, not by the commands.
 
 ```markdown
 ### N. Summary
 Use the template at [skills/reporting/templates/<command>-summary.md] following the structural rules in [skills/reporting/SKILL.md].
-
-## Continuation Checkpoint
-Use the template at [skills/reporting/templates/<command>-checkpoint.md].
 ```
 
-When a new command is added, drop a new template file into [templates/](templates/) following the outer shapes documented above. The structural rules apply automatically.
+When a new end-to-end command is added:
+
+1. Drop a `<command>-summary.md` template into [templates/](templates/) following the Summary outer shape.
+2. If the command has command-specific Workflow fields worth capturing on pause, drop a `<command>-checkpoint.md` template too — `/checkpoint` will pick it up automatically by command name. Skip this file for commands that need no extra fields beyond the generic header.

--- a/skills/reporting/templates/address-feedback-checkpoint.md
+++ b/skills/reporting/templates/address-feedback-checkpoint.md
@@ -1,0 +1,10 @@
+# /address-feedback Continuation Checkpoint Extension
+
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/address-feedback`, replace the generic `Phase:` field with the `/address-feedback`-specific enum and add the PR identifier:
+
+```markdown
+- Phase: gather / complexity-gate / investigate / triage / fix / review / draft / post / summarize
+- PR: <number> — <title>
+```
+
+Triage counts, review status, and post status belong in `## Current Status`.

--- a/skills/reporting/templates/create-feature-checkpoint.md
+++ b/skills/reporting/templates/create-feature-checkpoint.md
@@ -1,14 +1,12 @@
-# /create-feature Continuation Checkpoint Template
+# /create-feature Continuation Checkpoint Extension
 
-Follow the structural rules in [../SKILL.md](../SKILL.md). Resume specifics live in the Progress Update entry — the Continuation Checkpoint header carries only workflow metadata.
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/create-feature`, replace the generic `Phase:` field with the `/create-feature`-specific enum:
 
 ```markdown
-## Continuation Checkpoint — [ISO timestamp]
-### Workflow
-- Top-level command: /create-feature <arguments>
 - Phase: input / complexity-gate / plan-mode / plan-md-write / review-iterations / action-gate / implement-and-review / summarize
-- Active plan: PLAN.md (standard path) | none (trivial / moderate)
 ```
+
+No additional Workflow fields beyond the phase enum — `/create-feature` doesn't carry extra command-specific state on the checkpoint header.
 
 When `Active plan: PLAN.md` is set, resuming sessions can read PROJECT.md alone for orientation — only load PLAN.md if the next phase requires it (review iterations or implementation slice).
 

--- a/skills/reporting/templates/create-tests-checkpoint.md
+++ b/skills/reporting/templates/create-tests-checkpoint.md
@@ -1,0 +1,9 @@
+# /create-tests Continuation Checkpoint Extension
+
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/create-tests`, replace the generic `Phase:` field with the `/create-tests`-specific enum:
+
+```markdown
+- Phase: scope / review-tests / write-tests / verify / review / summarize
+```
+
+No additional Workflow fields. Tests added so far and verification status belong in `## Current Status`.

--- a/skills/reporting/templates/fix-bug-checkpoint.md
+++ b/skills/reporting/templates/fix-bug-checkpoint.md
@@ -1,15 +1,13 @@
-# /fix-bug Continuation Checkpoint Template
+# /fix-bug Continuation Checkpoint Extension
 
-Follow the structural rules in [../SKILL.md](../SKILL.md). Resume specifics live in the Progress Update entry — the Continuation Checkpoint header carries only workflow metadata.
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/fix-bug`, append these additional fields to the `### Workflow` block:
 
 ```markdown
-## Continuation Checkpoint — [ISO timestamp]
-### Workflow
-- Top-level command: /fix-bug <arguments>
 - Phase: input / complexity-gate / existing-fix-check / plan-mode / plan-md-write / implement-and-review / qa-validate / summarize
-- Active plan: PLAN.md (standard path) | none (trivial / moderate)
 - Existing-fix status: FIXED_UPSTREAM | FIX_PENDING_PR | UNFIXED | SKIPPED | pending
 ```
+
+The `Phase` line replaces the generic `Phase:` field with the `/fix-bug`-specific enum. The `Existing-fix status:` line is added below the generic fields.
 
 When `Active plan: PLAN.md` is set, resuming sessions can read PROJECT.md alone for orientation — only load PLAN.md if the next phase requires it (implementation or QA validation).
 

--- a/skills/reporting/templates/fix-ci-checkpoint.md
+++ b/skills/reporting/templates/fix-ci-checkpoint.md
@@ -1,0 +1,9 @@
+# /fix-ci Continuation Checkpoint Extension
+
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/fix-ci`, replace the generic `Phase:` field with the `/fix-ci`-specific enum:
+
+```markdown
+- Phase: gather-logs / classify / ownership-check / complexity-gate / rca / gate / apply / verify / review / summarize
+```
+
+No additional Workflow fields. Failure classification, gate result, review status, and files changed belong in `## Current Status`.

--- a/skills/reporting/templates/review-plan-checkpoint.md
+++ b/skills/reporting/templates/review-plan-checkpoint.md
@@ -1,0 +1,9 @@
+# /review-plan Continuation Checkpoint Extension
+
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/review-plan`, replace the generic `Phase:` field with the `/review-plan`-specific enum:
+
+```markdown
+- Phase: read-plan / detect-reviewers / review-iterations / cold-read / update / summarize
+```
+
+No additional Workflow fields. Reviewers selected, current scores, and revision count belong in `## Current Status`.

--- a/skills/reporting/templates/review-pr-checkpoint.md
+++ b/skills/reporting/templates/review-pr-checkpoint.md
@@ -1,0 +1,19 @@
+# /review-pr Continuation Checkpoint Extension
+
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/review-pr`, replace the generic `Phase:` field with the `/review-pr`-specific enum and add the PR identifier:
+
+**Single-PR mode**:
+
+```markdown
+- Phase: gather / complexity-gate / understand-problem / detect-team / launch-review / pattern-analysis / scoring / gate / post / summarize
+- PR: <number> — <title>
+```
+
+**Batch mode**:
+
+```markdown
+- Mode: batch
+- Phase: gather-list / dispatch-reviews / collect-results / batch-summary
+```
+
+Reviewer team, scores, recommendation, and post status (single-PR), or per-PR completion counts (batch) belong in `## Current Status`.

--- a/skills/reporting/templates/run-test-plan-checkpoint.md
+++ b/skills/reporting/templates/run-test-plan-checkpoint.md
@@ -1,0 +1,9 @@
+# /run-test-plan Continuation Checkpoint Extension
+
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/run-test-plan`, replace the generic `Phase:` field with the `/run-test-plan`-specific enum:
+
+```markdown
+- Phase: resolve-plan / review-plan / execute / capture-evidence / report / summarize
+```
+
+No additional Workflow fields beyond the phase enum. Plan score, execution counts, and evidence status belong in `## Current Status` (Done / In Progress / Next / Blocked), not on the checkpoint header.

--- a/skills/reporting/templates/test-pr-checkpoint.md
+++ b/skills/reporting/templates/test-pr-checkpoint.md
@@ -1,0 +1,10 @@
+# /test-pr Continuation Checkpoint Extension
+
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/test-pr`, replace the generic `Phase:` field with the `/test-pr`-specific enum and add the PR identifier:
+
+```markdown
+- Phase: resolve-pr / detect-url / assess-impact / derive-scenarios / confirm-scenarios / execute / report
+- PR: <number> — <title>
+```
+
+Impact tier, scenarios, and per-scenario results belong in `## Current Status`.

--- a/skills/reporting/templates/update-tests-checkpoint.md
+++ b/skills/reporting/templates/update-tests-checkpoint.md
@@ -1,0 +1,9 @@
+# /update-tests Continuation Checkpoint Extension
+
+`/checkpoint` writes the generic `## Continuation Checkpoint` block (see [../SKILL.md](../SKILL.md) and [../../../commands/checkpoint.md](../../../commands/checkpoint.md)). When the detected top-level command is `/update-tests`, replace the generic `Phase:` field with the `/update-tests`-specific enum:
+
+```markdown
+- Phase: scope / gap-analysis / update-tests / verify / review / commit / summarize
+```
+
+No additional Workflow fields. Existing-suite status, files changed, and verification status belong in `## Current Status`.

--- a/skills/shortcut/references/report.md
+++ b/skills/shortcut/references/report.md
@@ -33,15 +33,25 @@ Read `rules/shortcut-api.md` for the global Shortcut routing constraints.
 2. **Upload evidence** (if any)
 
    Upload files before posting the comment so the comment can reference the hosted URLs.
-   Use the `/files` endpoint (not `/stories/<id>/files`), linking via `story_id`:
+   Use the `/files` endpoint (not `/stories/<id>/files`).
+
+   **For inline images in the comment body** (screenshots embedded via markdown), upload *without* `story_id`. The returned `url` is workspace-scoped and renders in markdown, but the file does not appear in the story's Files sidebar — keeps the story clean when the image is only meaningful in context of the comment:
+   ```bash
+   shortcut_call 'curl -s -X POST "https://api.app.shortcut.com/api/v3/files" \
+     -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
+     -F "file0=@<path>"'
+   ```
+
+   **For evidence that should be attached to the story** (videos, logs, anything reviewers should find via the Files panel), include `story_id`:
    ```bash
    shortcut_call 'curl -s -X POST "https://api.app.shortcut.com/api/v3/files" \
      -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
      -F "file0=@<path>" \
      -F "story_id=<id>"'
    ```
+
    Do not pass `description` as a form field — it causes a validation error.
-   Capture the returned `url` for embedding in the comment.
+   Capture the returned `url` for embedding in the comment (`![alt](<url>)` for images).
    Name video files descriptively: `sc-<id>-<what-was-tested>.webm`.
 
 3. **Post the report comment**
@@ -76,61 +86,11 @@ Read `rules/shortcut-api.md` for the global Shortcut routing constraints.
    ```
    Fetch workflow states from `/workflows` to map names to IDs. Cache per session.
 
-## Report Template
+## Report Body — see `qa/references/write-report.md`
 
-Reports should read like a human QA tester wrote them — narrative, concise, evidence-linked. No tables, no metadata headers, no PASS/FAIL grids. Just tell the story of what you did and what you found.
+The body of the comment (shape, tone, repro/result/evidence structure, narrative-not-technical rules, single-flow vs multi-scenario templates, worked examples) is canonical and destination-agnostic — it lives in [skills/qa/references/write-report.md](../../qa/references/write-report.md). Read that for content rules and load the per-shape template/example from `qa/references/write-report/` when actually drafting.
 
-### Structure
-
-```markdown
-## QA Verification — PASS ✅ / FAIL ❌ / PARTIAL ⚠️
-
-**Tested on**: <environment URL or description> (<version/branch info>)
-**Date**: <YYYY-MM-DD>
-**Tester**: <who or what ran the test>
-
-### Repro steps followed:
-1. <what you actually did, step by step>
-2. <be specific — name the dashboard, chart, page, action>
-3. <include what you looked for and how you verified>
-
-### Result:
-**<One-sentence verdict.>** <2-3 sentences of narrative explaining what you observed. Be specific about what rendered, what didn't break, what you checked.>
-
-### Evidence:
-[<descriptive-filename.webm>](<shortcut media URL>)
-```
-
-### Writing Guidelines
-
-- **Narrative over structure**: "Opened the dashboard, scrolled through all charts, hovered over cells to check for artifacts" beats "Scenario 1: Load dashboard: PASS"
-- **Specific over generic**: Name the actual dashboard, chart, page, feature flag, user role
-- **One video beats ten screenshots**: Record a Playwright video of the full repro flow
-- **Verdict first, then details**: Lead with whether it passed, then explain what you saw
-- **Link evidence inline**: Embed the video/screenshot URL directly, don't put it in a separate section
-- **Keep it short**: If the fix works, say so in 3-4 sentences. Save long reports for failures.
-
-### Example (real — sc-98396)
-
-```markdown
-## QA Verification — PASS ✅
-
-**Tested on**: https://example.us1a.app-stg.preset.io (staging 6.0.0.6rc1)
-**Date**: 2026-02-20
-**Tester**: Playwright automation
-
-### Repro steps followed:
-1. Opened the existing "Treemap" chart (slice_id=14) from the World Bank's Data dashboard in Explore view
-2. Chart rendered with dimensions: region, country_code and metric: Population Total
-3. Visually inspected all treemap category rectangles across all regions
-4. Hovered over multiple cells (CHN, IND, JPN, RUS, BRA, NGA) to verify no white lines appear on hover
-
-### Result:
-**Bug appears fixed.** No white vertical lines visible in the middle of any treemap category cells. The category rectangles render cleanly with solid colors and proper borders between cells only (not through them).
-
-### Evidence:
-[sc-98396-treemap-no-white-lines.webm](https://media.app.shortcut.com/...)
-```
+This file owns only the **Shortcut-specific mechanics** above (file upload via `/files`, comment POST, PR linking, state updates) and the **output confirmation** below.
 
 ## Output
 


### PR DESCRIPTION
## Summary

Three related cleanups to the cherry-pick, checkpoint, and reporting skills:

- **Cherry-pick scope-leak enforcement** (`6967ee8`, `ce7b75c`) — Step 7 split into 7a (mandatory subagent for leak detection on every cherry, no exceptions) and 7b (correctness validation on main thread). Drops the "fresh context, how is flexible" loophole that allowed self-validation. Adds a verifiable `Scope Audit` column to the execution table and final report — orchestrator refuses `Applied` without literal `scope-audit.sh` output + per-hunk verdict from the subagent. Metrics vocabulary aligned (`CLEAN | LEAKED-REVERTED | ESCALATED`, promoted out of `gate_decisions`).
- **Checkpoint ownership** (`ce21a8a`) — `/checkpoint` is now the single owner of `## Continuation Checkpoint` sections. Removed duplicate inline checkpoint blocks from 8 commands; per-command extension templates carry only phase enum + one workflow-identifying field.
- **QA report body extraction** (`ce21a8a`) — Body shape moved to `skills/qa/references/write-report.md` with templates and worked examples; `shortcut/references/report.md` trimmed to destination mechanics only and now documents both upload variants (inline-only vs Files-panel evidence).

## Why

The skill-bypassed-but-actually-just-soft-enforcement pattern showed up in real cherry-pick leaks: `/cherry-pick` ran, the spec required scope audit on every cherry, but nothing in the report or contract made the audit verifiable. A self-validating thread could plausibly claim "audit clean" without running it. This PR makes the audit a structurally required artifact.

The checkpoint and reporting cleanups were standing duplications that shipped contradictory shapes across commands.

## Test plan

- [ ] `/cherry-pick <pr>` on a clean apply — verify the orchestrator spawns a leak-detection subagent and the final-report execution table contains a populated `Scope Audit` field.
- [ ] `/cherry-pick <pr>` on a cherry that intentionally drags an adjacent hunk — verify the subagent flags it, main thread reverts, subagent re-runs to `CLEAN`.
- [ ] `/checkpoint` from inside `/fix-bug`, `/run-test-plan`, `/test-pr` — verify the canonical lean header is written from the per-command extension template, no duplicate sections.
- [ ] `/test-pr` posting evidence — verify it routes to `qa/references/write-report.md` for body shape and `shortcut/references/report.md` (or GH equivalent) for posting mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)