### PR TITLE
feat: add /check-resources and stale-container guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ ai-toolkit/
     ├── metrics.md               # Workflow metrics summary
     ├── show-cost.md             # Token usage and cost summary
     ├── optimize-cost.md         # Usage pattern analysis and recommendations
+    ├── check-resources.md       # Local environment capacity check
     └── toolkit-doctor.md        # Structural health check
 ```
 
@@ -180,6 +181,11 @@ ai-toolkit/
 | `/show-cost` | Token usage and cost summary for the current session |
 | `/optimize-cost` | Usage pattern analysis and cost-reduction recommendations |
 | `/metrics` | Aggregate workflow metrics from `.claude/metrics.jsonl` |
+
+### Environment
+| Command | Purpose |
+|---------|---------|
+| `/check-resources` | Local environment capacity check — running containers, stale ones, headroom verdict |
 
 ### Learning & Memory
 | Command | Purpose |

--- a/commands/check-resources.md
+++ b/commands/check-resources.md
@@ -1,0 +1,82 @@
+# /check-resources - Local Environment Capacity Check
+
+> **When**: You want to know what Docker containers are running, which look stale, and whether you have headroom to start another stack.
+> **Produces**: A capacity report — host vs Docker daemon ceilings, current usage, stale-container list, and a go/no-go recommendation.
+
+## Usage
+```
+/check-resources         # Full report
+/check-resources stale   # Only show stale containers
+```
+
+## Steps
+
+### 1. Gather Capacity Signals
+
+Run these in parallel:
+
+```bash
+docker info | grep -E "CPUs|Total Memory|Server Version"
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Image}}\t{{.RunningFor}}"
+docker stats --no-stream --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}"
+sysctl -n hw.memsize hw.ncpu
+top -l 1 -n 0 | grep -E "Load Avg|PhysMem"
+```
+
+If `docker info` errors (daemon not running), report that and stop — there's nothing more to check.
+
+### 2. Identify Stale Containers
+
+A container is **stale** if any of these are true:
+- `STATUS` shows `Up` for **more than 24 hours**
+- Name contains a feature/branch prefix (`fix-*`, `feat-*`, `bug-*`, etc.) that doesn't match the current git branch in any tracked working directory
+- Image was built > 7 days ago for an ephemeral local stack (best-effort; skip if unclear)
+
+Do **not** stop containers automatically. List them with their age and ask the user which to stop.
+
+### 3. Compute Headroom
+
+- **Docker memory headroom** = `Total Memory` (from `docker info`) − sum of `MemUsage` across containers (from `docker stats`).
+- **Host memory headroom** = host RAM − `PhysMem used` (from `top`).
+- **Go/no-go for another Superset-class stack** (~5 GB):
+  - Docker headroom > 6 GB **and** host PhysMem unused > 4 GB → `GO`
+  - Docker headroom 3–6 GB → `MARGINAL — consider stopping a stale stack first`
+  - Docker headroom < 3 GB → `NO-GO — raise Docker Desktop cap or stop a stack`
+
+### 4. Render Report
+
+Format:
+
+```
+=== Resources ===
+Host:   <chip>, <cores> cores, <GB> RAM   load avg <n>   PhysMem unused <GB>
+Docker: cap <GiB>, <N> containers running, aggregate <GB> (<%> of cap)
+
+Running:
+  <name>  <status>  <mem>  <cpu>
+  ...
+
+Stale (> 24h or off-branch):
+  <name>  up <duration>  <reason>
+  ...
+  → Stop any of these? (user confirms before action)
+
+Headroom: <GB> Docker / <GB> host
+Verdict:  GO | MARGINAL | NO-GO  for another Superset-class stack
+```
+
+If `stale` argument was passed, render only the Stale section.
+
+### 5. Offer Next Actions
+
+Based on verdict:
+- `GO` — name the next stack the user is likely starting and proceed only if they confirm.
+- `MARGINAL` — list the stale containers as candidates to stop, with the exact `docker stop <names>` command.
+- `NO-GO` — recommend either stopping containers or raising the Docker Desktop memory cap (Settings → Resources → Memory). Do not change Docker Desktop settings programmatically.
+
+## Notes
+
+- This command is read-only by default. The only mutation it may perform is `docker stop` on user-confirmed names.
+- The "stale" heuristic is conservative — false positives are fine (the user can say "keep that one"), false negatives waste capacity.
+- Run this before `/create-feature`, `/fix-bug`, or any workflow that will spin up a stack, when you suspect things are crowded.
+- Always-on guardrails in `rules/resource-management.md` cover the lightweight version of this check; this command is the on-demand deep dive.

--- a/rules/resource-management.md
+++ b/rules/resource-management.md
@@ -17,9 +17,16 @@ Use this file as the always-on index. Load the scoped rule only when the task ne
 
 ## Always-On Guardrails
 
-- Before starting containers, check what is already running.
-- If more than two containers are already running, show them to the user and ask before starting another stack.
+- Before starting containers, run `docker ps` and check **two things**:
+  1. **How many** are running — if more than two, show them and ask before starting another stack.
+  2. **Which look stale** — surface any container running > 24h (column: `STATUS`) or whose name references an old branch/feature, list them with age, and ask the user whether to stop them. Do not stop without confirmation.
 - Before heavy test runs, choose worker counts intentionally; do not blindly use CPU count.
 - In worktrees, assume dependencies, build outputs, and env files may be missing until checked.
+
+## Host Capacity Reference
+
+Current host: Apple M5 Pro, 15 cores, 48 GB RAM. Docker Desktop's memory cap is set independently of host RAM — check `docker info | grep "Total Memory"` to see it. The daemon ceiling is the binding constraint for "how many stacks can I run", not host RAM. A Superset stack uses 4–6 GB; with the cap at 7.75 GiB you can realistically run one heavy stack plus light services. With the cap at 16–24 GB you can run two to three concurrent stacks.
+
+If the user is hitting capacity limits, suggest raising Docker Desktop → Settings → Resources → Memory rather than killing work. Do not change Docker Desktop settings programmatically.
 
 Detailed stack, worktree, and worker-count rules are skill-scoped so they only load for environment prep or testing work.

--- a/skills/preflight/rules.md
+++ b/skills/preflight/rules.md
@@ -5,11 +5,19 @@ Read this when a workflow is preparing a local app, Docker stack, or git worktre
 ## Docker Container Management
 
 Before starting any Docker containers:
-1. Run `docker ps` to check running containers.
-2. If two or fewer containers are running, proceed.
-3. If more than two containers are running, show the running containers to the user and ask whether to stop any before starting new ones, or start anyway.
+1. Run `docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"` to inspect running containers.
+2. **Stale check** — flag any container whose `STATUS` shows `Up` for more than 24 hours, or whose name contains a feature/branch prefix that doesn't match the current working branch (e.g., `fix-foo-*`, `feat-bar-*`). List the stale ones with their age and ask the user whether to stop them before starting new work. Do not stop containers without confirmation.
+3. **Count check** — if two or fewer non-stale containers are running, proceed. If more than two, show the running containers to the user and ask whether to stop any before starting another stack.
 
-Each Superset stack can use 4-6 GB RAM. Multiple stacks can saturate the Docker VM and crash the host.
+### Capacity math
+
+Run `docker info | grep -E "CPUs|Total Memory"` once per session to know the daemon's ceiling. The Total Memory value caps the *aggregate* across all containers, regardless of host RAM.
+
+- Each Superset stack uses 4–6 GB.
+- Lightweight services (redis, postgres, single web service) typically use < 200 MB each.
+- If aggregate `MemUsage` (from `docker stats --no-stream`) is approaching 70 % of the daemon Total Memory, warn the user before starting another stack — running out of Docker memory triggers OOM kills, not gradual slowdown.
+
+If the daemon cap looks too low for the user's workflow (e.g., < 12 GB on a host with 32 GB+ of RAM), mention raising it in Docker Desktop → Settings → Resources → Memory. Do not modify Docker Desktop settings programmatically.
 
 ## Worktree Management
 


### PR DESCRIPTION
## Summary
- New `/check-resources` slash command: reports host vs Docker daemon capacity, lists running containers, flags stale ones (>24h or off-branch names), and gives a GO/MARGINAL/NO-GO verdict for starting another stack.
- Always-on `rules/resource-management.md`: adds stale-container surfacing to the pre-stack check and a "Host Capacity Reference" section clarifying that the Docker Desktop memory cap (not host RAM) is the binding constraint for concurrent stacks.
- `skills/preflight/rules.md`: expanded the docker-ps step with explicit stale heuristics, capacity math, and a 70%-of-cap warning threshold.
- README updated with the new command and an "Environment" subsection so toolkit-doctor stays clean.

## Test plan
- [ ] `./install.sh` succeeds and `/check-resources` appears in the live skill list
- [ ] `/toolkit-doctor` reports no new DRIFT or FAIL entries
- [ ] `/check-resources` runs end-to-end: shows daemon cap, container list, stale flags, headroom verdict
- [ ] `/check-resources stale` renders only the stale section

🤖 Generated with [Claude Code](https://claude.com/claude-code)