### PR TITLE
chore(skills): add pre-commit gate to cherry-pick validation

### DIFF
--- a/skills/cherry-pick/SKILL.md
+++ b/skills/cherry-pick/SKILL.md
@@ -102,7 +102,7 @@ The orchestrator may not mark a cherry `Applied` without this report. If the sub
 
 **7b. Correctness validation — main thread.**
 
-Conflict-marker scan, build, type-check, targeted tests. Build failures are loud and don't need a fresh context — the main thread handles them.
+Conflict-marker scan, **pre-commit on changed files**, build, type-check, targeted tests. Pre-commit is mandatory — conflict resolution often re-indents lines past length limits, and pre-commit is what CI runs. If pre-commit auto-fixes or you make manual fixes, `git commit --amend --no-edit` before pushing. Do not push, then amend, then force-push.
 
 → Full procedure (subagent contract, LLM audit, validation order, status labels, dependency manifest rule): [references/validate.md](references/validate.md)
 

--- a/skills/cherry-pick/gotchas.md
+++ b/skills/cherry-pick/gotchas.md
@@ -78,6 +78,18 @@ Format per entry: **Symptom** → **Why** → **Do instead** → **First seen**.
 
 ---
 
+## Conflict resolution adds indent levels and trips line-length lint
+
+**Symptom:** Cherry-pick applies and tests pass locally, but pre-commit / CI fails with `E501 Line too long` on lines that were fine on the source branch.
+
+**Why:** When the target nests the affected code one level deeper than the source (e.g., target wraps `sync_wrapper` in an `else:` block that source doesn't have), the cherry-picked lines arrive with extra indentation. Comments and string literals near the 88/100-char limit on source go over on target. `git cherry-pick` doesn't reformat, and a clean `pytest` says nothing about lint.
+
+**Do instead:** Run pre-commit on the changed files as part of step 7b validation, **before push**. Fix any failures (auto-fixers via `git add` + `--amend`, manual fixes via edit + `--amend`). Don't push first and force-push later — amend pre-push when CI hasn't run yet.
+
+**First seen:** PR #39798 cherry-pick to 6.0-release — comment block landed at indent 20 (vs source indent 16), two lines over 88 chars, surfaced only when CI ran.
+
+---
+
 ## Validation status overstated as "Tested" when only build ran
 
 **Symptom:** Execution table says `Tested` for a cherry-pick where only the build passed; targeted tests existed but weren't executed.

--- a/skills/cherry-pick/references/validate.md
+++ b/skills/cherry-pick/references/validate.md
@@ -92,8 +92,9 @@ Runs only after the scope-leak subagent returns `CLEAN`. Build/test failures are
 
 At minimum:
 1. Confirm no conflict markers.
-2. Run the smallest relevant build or type-check.
-3. Run targeted tests covering the changed area.
+2. **Run pre-commit on changed files** (see "Pre-Commit Gate" below). Mandatory — this is what CI runs, and conflict resolution often re-indents lines past length limits.
+3. Run the smallest relevant build or type-check.
+4. Run targeted tests covering the changed area.
 
 For config-only changes (YAML, JSON, feature flags) where there is no build or test to run, validate by parsing the file programmatically and verifying the intended effect (load YAML and assert the expected keys/values are present).
 
@@ -101,6 +102,29 @@ Run broader validation when:
 - the cherry-pick touched shared infrastructure
 - the target branch differs materially from the source branch
 - the targeted checks fail to provide confidence
+
+## Pre-Commit Gate
+
+Run pre-commit on the changed files **after** the cherry-pick commit exists and **before** pushing. This is the single consistent rule for both clean applies and conflicted applies — clean applies have no `--continue` step to hook into.
+
+```bash
+pre-commit run --files <changed-file-1> <changed-file-2>
+# or, if pre-commit isn't the repo's tool, use the equivalent CI lint/format command
+```
+
+**If pre-commit auto-fixes files** (ruff-format, end-of-files, trailing whitespace, etc.):
+```bash
+git add <fixed-files>
+git commit --amend --no-edit
+```
+
+**If pre-commit reports manual-fix errors** (line length, lint rules without fixers): edit the file, then amend as above.
+
+**Re-run pre-commit after amend** until it passes on the changed files.
+
+**Pre-existing failures on unrelated files** (warnings on files the cherry-pick didn't touch) are out of scope — note them in the validation summary but do not attempt to fix them within the cherry-pick.
+
+The amend stays local since the push step is gated on validation passing. Do not push, then amend, then force-push, when amending pre-push would have worked.
 
 ## Minimum Validation Bar
 


### PR DESCRIPTION
## Summary
- Mandates pre-commit on changed files during cherry-pick validation (step 7b), with amend-before-push to avoid force-push churn after the fact.
- Captures the underlying gotcha: conflict resolution can re-indent lines past length limits, passing local pytest but failing CI lint (first seen on PR #39798).

## Test plan
- [ ] Walk through `skills/cherry-pick/SKILL.md` step 7b on a sample backport that triggers a pre-commit lint fix; confirm the amend-before-push path keeps history clean.
- [ ] Verify `skills/cherry-pick/references/validate.md` and `skills/cherry-pick/gotchas.md` cross-link consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)