### PR TITLE
feat(cherry-pick): per-cherry push as phase 8 + dependency-aware batch sequencing

### DIFF
--- a/skills/cherry-pick/SKILL.md
+++ b/skills/cherry-pick/SKILL.md
@@ -36,7 +36,7 @@ If the workflow would cross a contract boundary, stop and ask — do not cross f
 
 ## Single Cherry-Pick Flow
 
-Each cherry-pick runs all 7 phases. No phase may be skipped — the diff audit in step 7 is the only defense against scope leak (see gotchas.md).
+Each cherry-pick runs all 8 phases. No phase may be skipped — the diff audit in step 7 is the only defense against scope leak (see gotchas.md), and the push in step 8 is what attributes CI signal to the right cherry.
 
 ### 1. Investigate (Opus)
 
@@ -106,10 +106,17 @@ Conflict-marker scan, **pre-commit on changed files**, build, type-check, target
 
 → Full procedure (subagent contract, LLM audit, validation order, status labels, dependency manifest rule): [references/validate.md](references/validate.md)
 
-**Push after each successful cherry-pick** so CI runs against the change:
+### 8. Push (main thread — mandatory, per cherry)
+
 ```bash
 git push
 ```
+
+Push **immediately after** step 7 passes for *this* cherry, before starting the next one. Do not batch pushes at the end of a multi-cherry run.
+
+**Why:** CI must run against each cherry independently so a failure points at the offending change, not the bundle. Batching defeats per-cherry attribution and forces bisection later.
+
+The only exception is when the user explicitly asks for batched push (e.g., to reduce CI cost). In that case, confirm before deferring.
 
 ## Batch Cherry-Pick Flow
 
@@ -118,10 +125,10 @@ When multiple PRs/SHAs are provided, the main agent acts as a **thin orchestrato
 **Invariant: each cherry must start with clean context.** Subagents are the usual mechanism, but any isolation that prevents cherry #10 from inheriting cherry #1's diffs and decisions works. What matters is that the agent working on cherry N does not carry state from cherries 1..N-1.
 
 1. **Sequence planning** — run [references/batch-sequence.md](references/batch-sequence.md) to determine execution order based on dependencies. Sonnet is sufficient.
-2. **Per-cherry execution** — for each cherry in sequence, run the full single flow (steps 1–7) in an isolated context.
+2. **Per-cherry execution** — for each cherry in sequence, run the full single flow (steps 1–8) in an isolated context. **Step 8 (push) runs per cherry, not after the batch.** If you find yourself thinking "I'll push them all at the end," stop — re-read step 8.
 3. **Status tracking** — record results in the execution table. If one fails, do NOT continue with subsequent dependent picks. Independent picks may continue.
 4. **Escalation** — surface escalations to the user, relay answers back.
-5. **Final report** — collect results and produce the document phase output.
+5. **Final report** — collect results and produce the document phase output. By this point all successful cherries are already pushed; the report summarizes, it does not push.
 
 **Why isolation matters:** with 15 cherry-picks, inline processing pollutes context with prior diffs by cherry #10. Quality degrades silently — conflicts start looking alike, decisions bleed across cherries.
 
@@ -144,7 +151,7 @@ The full 13-column execution table format is in [examples/execution-table.md](ex
 
 ## Continuation Checkpoint
 
-Phases: investigate / gate / plan / plan-review / apply / adapt / validate / document
+Phases: investigate / gate / plan / plan-review / apply / adapt / validate / push / document
 
 State to checkpoint:
 - Target branch

--- a/skills/cherry-pick/gotchas.md
+++ b/skills/cherry-pick/gotchas.md
@@ -90,6 +90,18 @@ Format per entry: **Symptom** → **Why** → **Do instead** → **First seen**.
 
 ---
 
+## Batched push at end of batch instead of per-cherry
+
+**Symptom:** All cherry-picks in a multi-PR batch get committed locally, then pushed in a single `git push` at the end. CI runs once against the bundle. If a later cherry breaks something, the failure can't be attributed without bisecting the bundled push.
+
+**Why:** `git push` happening once per batch is the natural rhythm when you're orchestrating a tight loop ("apply, validate, next, …, done, push"). The skill's per-cherry push directive is easy to skim past because it sits as a trailing note after the validate references rather than as a numbered phase, and the Batch Flow section doesn't restate it.
+
+**Do instead:** Step 8 (push) is a numbered phase that runs **per cherry, before starting the next one**. Treat the per-cherry loop body as steps 1–8, not 1–7. If you're tempted to defer push, re-read step 8. Only batch pushes when the user explicitly requests it (e.g., to reduce CI cost) — confirm first.
+
+**First seen:** 4-PR batch into 6.0-release, 2026-05-06. Pushed once at the end; user flagged it.
+
+---
+
 ## Validation status overstated as "Tested" when only build ran
 
 **Symptom:** Execution table says `Tested` for a cherry-pick where only the build passed; targeted tests existed but weren't executed.
@@ -106,3 +118,17 @@ Format per entry: **Symptom** → **Why** → **Do instead** → **First seen**.
 If tests existed and weren't run, flag the gap explicitly with what was available, why skipped, and recommended follow-up.
 
 **First seen:** Standing rule encoded in validate phase.
+
+---
+
+## Orchestrator prescribes `git apply` for partial cherry-picks
+
+**Symptom:** A partial cherry-pick lands with the wrong author (the local user instead of the source PR author) and a hand-written commit message that doesn't match `cherry-pick -x` convention. Detected post-push when reviewing `git log` author/subject.
+
+**Why:** When the orchestrator builds a subagent prompt for a partial cherry-pick (some files inapplicable on target), it's tempting to prescribe `git format-patch -1 <sha> -- <subset> | git apply --3way` because it cleanly limits the file set without modify/delete conflicts. But `git apply` discards source author and forces a manual `git commit`, which defaults the author to the local user and requires writing the message by hand — both of which break `cherry-pick -x` convention. The subagent dutifully follows the prompt, the apply.md escalation ladder is bypassed, and the bug only surfaces when a human reads the commit log.
+
+**Do instead:** Even for partials, prescribe `git cherry-pick -x <sha>` in the subagent prompt. Modify/delete conflicts on inapplicable files resolve cleanly with `git rm <inapplicable-files>`. The resulting `git cherry-pick --continue` preserves source author and produces the standard subject + `(cherry picked from commit ...)` trailer automatically. The fact that some files were excluded shows up only in the diff — never in the message, never in the author.
+
+**Remediation if already pushed:** Reset to before the bad commit, re-run `git cherry-pick -x` properly, then re-cherry-pick (or `rebase --onto`) any subsequent commits onto the corrected base, then `git push --force-with-lease`. Do not just amend the message — that leaves the wrong author.
+
+**First seen:** 2026-05-08 batch into 6.0-release. Partial cherry-pick of PR #39636 used `git format-patch | git apply` per the subagent prompt I wrote; landed with author=Joe Li (should have been Amin Ghadersohi) and a modified subject `(partial)`. User flagged; remediation required reset + redo + force-push of 5 commits.

--- a/skills/cherry-pick/references/adapt.md
+++ b/skills/cherry-pick/references/adapt.md
@@ -90,3 +90,4 @@ Stop and ask for user input when:
 - the target branch lacks required architectural groundwork
 - dropping a bug fix leaves the underlying bug unaddressed on the target branch (surface the residual risk even if proceeding)
 - scope leak detection finds changes from adjacent commits that may be intentional prerequisites
+- a bundled PR contains sub-fixes that look unrelated to the main fix and would otherwise be dropped as scope creep — surface to the orchestrator with the list of sub-fixes proposed for exclusion and a one-line rationale per drop, rather than deciding alone. The user explicitly listed the PR in the batch, which generally implies they want everything in it; the orchestrator (or user) should confirm the drop, not the adapter.

--- a/skills/cherry-pick/references/batch-sequence.md
+++ b/skills/cherry-pick/references/batch-sequence.md
@@ -19,20 +19,24 @@ For each candidate change, run these analyses in parallel when possible:
    - Inspect changed files, intent, and nearby history just enough to order and triage
 
 2. **Dependency and overlap analysis**
-   - Check which changes touch the same files or modules
-   - Detect imports, APIs, or modules introduced by one change and consumed by another
+   - Run `${CLAUDE_SKILL_DIR}/scripts/batch-deps.sh <sha1> <sha2> ...` to get the mechanical signals: per-SHA file lists, SHA pairs sharing files, per-file coverage (×N count), author-date order, and a list of fully-independent SHAs eligible for parallel investigation.
+   - Read the output: every "[×2]" or higher entry in per-file coverage is a dependency point. The pairs above each describe an edge in the dependency graph.
+   - Detect imports, APIs, or modules introduced by one change and consumed by another — the script's per-SHA file list surfaces this; verify by inspecting hunks for any pair flagged with shared files.
 
 3. **Existing-fix scan**
-   - Check whether the target branch already contains an equivalent fix
-   - Exclude duplicates before planning order
+   - Quick mechanical filter first: for each source SHA, run `git log --grep="cherry picked from commit ${sha}" <target-branch>`. Any hits get classified `Skipped` immediately and never enter the execution table — this catches `-x`-attributed cherry-picks already on the branch in seconds, before any per-cherry investigation runs.
+   - For SHAs that pass the mechanical filter, the deeper [check-existing-fix reference](../../debug/references/check-existing-fix.md) handles squashed equivalents, partial backports already in place, and fixes done independently on the target.
+   - Exclude duplicates before planning order.
 
 ## Ordering Rules
 
-- Build a dependency graph across all requested changes
-- Topologically sort the graph
-- Independent changes may be investigated in parallel (orchestrator spawning subagents)
-- Actual cherry-pick application on the target branch remains sequential
-- Flag circular dependencies or ambiguous prerequisite chains as requiring user decision
+- Build the dependency graph from `batch-deps.sh` output: nodes = SHAs, edges = pairs flagged as sharing files.
+- Topologically sort. Author-date order from the script is a valid topo-sort *iff* no later commit reverts or replaces content from an earlier one — verify by inspecting any pair where the later commit is a `chore: remove`, `revert`, or `refactor` of code touched by the earlier commit. If you find a revert/replace pattern, swap those two.
+- Independent SHAs (the script's "Independence Check" section) may be investigated in parallel — the orchestrator should spawn one subagent per island concurrently.
+- Actual cherry-pick application on the target branch remains sequential.
+- Flag circular dependencies or ambiguous prerequisite chains as requiring user decision.
+
+**Why a real graph beats merge order:** if A modifies file F and B later removes F, applying A then B on the target requires A's adapter to integrate against the target's pre-removal F, then B's adapter to remove what's left. Applying B first (when safe by hunk inspection) lets A apply against a clean post-removal state. Merge order on master doesn't reveal this — only file-overlap analysis does.
 
 ## Dry-Run Rule
 
@@ -61,7 +65,7 @@ For `--plan-only`, the orchestrator also runs investigate + gate for each cherry
 | 2 | `<sha>` | #124 | <summary> | #123 | Must follow #123 |
 
 ### Parallelizable Groups
-[List which changes can be investigated in parallel because they're independent]
+[List which changes can be investigated in parallel because they're independent — copy from `batch-deps.sh` "Independence Check" section]
 ```
 
 Do not populate risk, confidence, or decision fields — those belong to per-cherry investigate and gate phases.

--- a/skills/cherry-pick/scripts/batch-deps.sh
+++ b/skills/cherry-pick/scripts/batch-deps.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# batch-deps.sh — file-overlap analysis for cherry-pick batches.
+#
+# Given a list of source SHAs (must be reachable in the local git repo), emits
+# the mechanical signals needed to build a real dependency-aware execution order:
+#
+#   1. Per-SHA file lists (author-date order, oldest first)
+#   2. SHA pairs that share files (dependency edges; the earlier one should
+#      generally come first, but verify by inspecting hunks for revert/replace)
+#   3. Per-file SHA coverage (files touched by 2+ SHAs are dependency points;
+#      files touched by 1 SHA are independent)
+#   4. Author-date execution order (a valid topological sort iff no later
+#      commit reverts or replaces content from an earlier one — verify this)
+#
+# This is mechanical. The LLM reads the output and decides:
+#   - parallel-investigation islands (zero shared files with all others)
+#   - whether author-date order is actually safe or needs a swap
+#   - which SHA pairs warrant the most careful conflict resolution
+#
+# Usage: batch-deps.sh <sha1> <sha2> [<sha3> ...]
+#
+# Exit codes:
+#   0 = analysis complete
+#   2 = invocation error or invalid SHA
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <sha1> <sha2> [<sha3> ...]" >&2
+  echo "Need at least 2 SHAs for dependency analysis." >&2
+  exit 2
+fi
+
+for sha in "$@"; do
+  if ! git rev-parse --verify "${sha}^{commit}" >/dev/null 2>&1; then
+    echo "error: ${sha} is not a valid commit" >&2
+    exit 2
+  fi
+done
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+# Build sorted (author date, full sha, short sha, subject) — oldest first
+for sha in "$@"; do
+  git show -s --format="%aI%x09%H%x09%h%x09%s" "$sha"
+done | sort -k1,1 > "$TMPDIR/sorted"
+
+# Per-SHA file lists; also record (file, short_sha) for overlap analysis
+echo "## Per-SHA File Lists (author-date order, oldest first)"
+echo
+while IFS=$'\t' read -r adate full_sha short_sha subj; do
+  echo "### $short_sha — $adate"
+  echo "    $subj"
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    echo "    - $f"
+    printf '%s\t%s\n' "$f" "$short_sha" >> "$TMPDIR/file_sha"
+  done < <(git diff-tree --no-commit-id --name-only -r "$full_sha")
+  echo
+done < "$TMPDIR/sorted"
+
+# SHA pairs sharing files
+echo "## SHA Pairs Sharing Files (dependency edges)"
+echo
+echo "Pairs with overlap need ordering. The earlier SHA (by author date) generally comes first; verify by inspecting hunks for revert/replace patterns."
+echo
+
+if [[ -s "$TMPDIR/file_sha" ]]; then
+  PAIRS=$(awk -F'\t' '
+    { files[$1] = files[$1] " " $2 }
+    END {
+      for (f in files) {
+        n = split(files[f], shas, " ")
+        c = 0
+        for (i = 1; i <= n; i++) if (shas[i] != "") arr[++c] = shas[i]
+        if (c >= 2) {
+          # Sort the SHAs in this group lexicographically for stable pair keys
+          for (i = 1; i <= c; i++) {
+            for (j = i + 1; j <= c; j++) {
+              if (arr[i] > arr[j]) { tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp }
+            }
+          }
+          for (i = 1; i < c; i++) {
+            for (j = i + 1; j <= c; j++) {
+              key = arr[i] " " arr[j]
+              pair_files[key] = pair_files[key] "\t" f
+            }
+          }
+        }
+        delete arr
+      }
+      for (p in pair_files) {
+        n = split(pair_files[p], files, "\t")
+        printf "%s\t%d\t", p, n - 1
+        first = 1
+        for (i = 1; i <= n; i++) {
+          if (files[i] != "") {
+            if (first) { first = 0 } else { printf "," }
+            printf "%s", files[i]
+          }
+        }
+        printf "\n"
+      }
+    }
+  ' "$TMPDIR/file_sha" | sort -k3,3rn -k1,1)
+
+  if [[ -z "$PAIRS" ]]; then
+    echo "  (no shared files — all SHAs are independent)"
+  else
+    while IFS=$'\t' read -r pair count files; do
+      printf "  %s — %d shared file(s)\n" "$pair" "$count"
+      echo "$files" | tr ',' '\n' | sed 's/^/      /'
+    done <<< "$PAIRS"
+  fi
+fi
+
+echo
+
+# Per-file SHA coverage
+echo "## Per-File SHA Coverage"
+echo
+echo "Files touched by 2+ SHAs are dependency points. Files touched by 1 SHA are safe."
+echo
+
+if [[ -s "$TMPDIR/file_sha" ]]; then
+  sort "$TMPDIR/file_sha" | awk -F'\t' '
+    {
+      if ($1 != prev) {
+        if (prev != "") {
+          if (count >= 2) printf "  [×%d] %s : %s\n", count, prev, shas
+          else printf "  [×1] %s : %s\n", prev, shas
+        }
+        prev = $1
+        shas = $2
+        count = 1
+      } else {
+        shas = shas " " $2
+        count++
+      }
+    }
+    END {
+      if (prev != "") {
+        if (count >= 2) printf "  [×%d] %s : %s\n", count, prev, shas
+        else printf "  [×1] %s : %s\n", prev, shas
+      }
+    }
+  ' | sort -k1,1 -k2,2
+fi
+
+echo
+
+# Author-date execution order
+echo "## Author-Date Execution Order"
+echo
+echo "Valid topological sort *if* no later commit reverts or replaces content from an earlier one. Verify by checking the overlap pairs above."
+echo
+n=0
+while IFS=$'\t' read -r adate full_sha short_sha subj; do
+  n=$((n + 1))
+  printf "  %2d. %s  %s  %s\n" "$n" "$short_sha" "$adate" "$subj"
+done < "$TMPDIR/sorted"
+
+echo
+echo "## Independence Check"
+echo
+
+if [[ -s "$TMPDIR/file_sha" ]]; then
+  ALL_SHAS=$(awk -F'\t' '{print $3}' "$TMPDIR/sorted" | sort -u)
+  OVERLAPPING_SHAS=$(awk -F'\t' '
+    { files[$1] = files[$1] " " $2 }
+    END {
+      for (f in files) {
+        n = split(files[f], shas, " ")
+        c = 0
+        for (i = 1; i <= n; i++) if (shas[i] != "") arr[++c] = shas[i]
+        if (c >= 2) for (i = 1; i <= c; i++) print arr[i]
+        delete arr
+      }
+    }
+  ' "$TMPDIR/file_sha" | sort -u)
+
+  INDEPENDENT=$(comm -23 <(echo "$ALL_SHAS") <(echo "$OVERLAPPING_SHAS") || true)
+  if [[ -n "$INDEPENDENT" ]]; then
+    echo "Independent SHAs (zero file overlap with any other in this batch — investigate in parallel):"
+    echo "$INDEPENDENT" | sed 's/^/  - /'
+  else
+    echo "No fully-independent SHAs in this batch."
+  fi
+fi


### PR DESCRIPTION
## Summary
- Promote `git push` from a trailing note to numbered **phase 8**, mandatory after each cherry-pick before starting the next. Batched-end pushes break per-cherry CI attribution.
- Add `scripts/batch-deps.sh` — emits per-SHA file lists, overlap pairs, per-file coverage, author-date order, and an independence-island check, so the sequencer builds a real dependency graph instead of trusting merge order.
- Wire the script into `references/batch-sequence.md`, plus a `git log --grep="cherry picked from commit <sha>"` mechanical pre-filter to skip already-landed cherries before per-cherry investigation runs.
- Adapter (`references/adapt.md`) must escalate bundled-PR sub-fix exclusions rather than dropping silently — a user-listed PR implies intent to take everything in it.
- Two new gotchas:
  - **Batched push at end of batch** (first seen 2026-05-06) — re-runs the warning so future orchestrators don't re-skim past it.
  - **`git format-patch | git apply` for partial cherry-picks** (first seen 2026-05-08) — discards source author and forces a hand-written subject. Always use `git cherry-pick -x` + `git rm <inapplicable-files>` instead, even for partials.

## Why
Two real-incident lessons from batch cherry-picks into the 6.0-release branch on 2026-05-06 and 2026-05-08. The author-mangling bug required a reset + redo + `--force-with-lease` of 5 commits to remediate, so the gotcha specifically prescribes `git cherry-pick -x` for partials and documents the recovery procedure.

## Test plan
- [ ] `batch-deps.sh <sha1> <sha2>` runs cleanly against any pair of commits in the local repo
- [ ] Phase 8 push directive is visible in both single and batch flows (no longer skimmable as a trailing note)
- [ ] `gotchas.md` table renders cleanly on GitHub
- [ ] Cherry-pick skill description still triggers on the usual phrases ("backport", "port to release branch", etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)