### PR TITLE
feat(create-pr): tightness check for PR titles and bodies

### DIFF
--- a/commands/create-pr.md
+++ b/commands/create-pr.md
@@ -48,6 +48,23 @@ Rules:
 - Human-readable — describe the user-facing "what", not the implementation detail
 - Examples: "feat: Add bulk filter editing for dashboards", "fix: Prevent chart crash on empty datasets"
 
+**Tightness check before finalizing.** Ask three questions; if any answer is no, rewrite:
+
+1. **Does every term in the title appear in a commit message, code comment, or external doc?** — Conversation-internal jargon ("channel-3", "Tier A", "Layer 2", or any label invented during planning that didn't make it into the codebase) is opaque to readers. Replace with the concrete domain term it stood for.
+2. **Does the title lead with the outcome, not the mechanism?** — "Add helper class X" / "Introduce normaliser Y" / "Refactor to pattern Z" describe what the code looks like; readers want to know what changes for users of the affected area. Lead with the problem solved or the capability gained.
+3. **Could a reader grep their codebase from this title to assess relevance?** — If the PR introduces an API that callers will adopt, name 1-2 of the key entry points (function names, route paths, env vars) so readers don't have to open the diff to know whether it touches their code.
+
+**Common anti-patterns to flag and rewrite:**
+
+| Anti-pattern | Example | Rewrite as |
+|---|---|---|
+| Invented abstraction label | `feat: introduce channel-3 helpers` | `feat: helpers for browser-direct navigation` |
+| Mechanism-first phrasing | `feat: add URL normaliser to API client` | `feat: strip backend URL prefixes for subdirectory deployments` |
+| Generic verb + noun | `chore: refactor exports` | `chore: collapse duplicate path utility into navigation module` |
+| Multi-thing list | `feat: helpers + normaliser + lint rule` | Pick the most user-visible outcome; mention secondaries in body |
+
+For dual-purpose PRs (feature + fix), pick the framing that matches the most user-visible outcome — even if the conventional-commits prefix is `feat`, the title text can lead with the problem ("prevent X bug via helpers Y").
+
 ### 4. Generate PR Body
 
 If a PR template exists, fill in each section from the gathered context.
@@ -67,6 +84,13 @@ If no template, use this default structure:
 ## Related
 [Link to ticket, issue, or prior PR if referenced in commits or PROJECT.md]
 ```
+
+**Body tightness check.** The same anti-patterns from the title check apply to the opening summary — readers form their first impression from the first paragraph. Specifically:
+
+- **Don't import conversation jargon into the body.** If a label was useful for organizing the planning discussion (channels, tiers, layers, phases) but never made it into commit messages or code, do not introduce it for the first time in the PR body. The reader can't follow back to where it was defined.
+- **Open with the user-visible problem or capability**, not the file list or the helper inventory. The reader decides whether to keep reading based on the first 1-2 sentences.
+- **Move implementation detail tables / file inventories below the rationale**, not above. Tables of "what's in this PR" are useful to maintainers but bury the answer to "why does this PR exist".
+- **Strip planning artefacts** — "skeleton commit", "first set of tests", "stubs that throw" — once the PR has grown past that phase. The body should reflect the PR's *current* state, not its development history.
 
 ### 5. Present for Review
 


### PR DESCRIPTION
## Summary
- Adds a 3-question gate before finalizing a PR title: jargon check, outcome-vs-mechanism, and greppability. If any answer is no, the title gets rewritten.
- Anti-pattern table covering invented-abstraction labels (`channel-3 helpers`), mechanism-first phrasing (`add URL normaliser`), generic verb+noun (`refactor exports`), and multi-thing lists.
- Body section gets the same treatment: don't import conversation jargon into the body, lead with the user-visible problem (not the file inventory), and strip planning artefacts (`skeleton commit`, `stubs that throw`) once the PR has matured past them.

## Why
Recent PRs have led with internal labels invented during planning conversations — "channel-3", "Tier A", "Layer 2" — that mean nothing to a cold reader. The fix is procedural: ask three questions before finalizing, and rewrite if any of them fail.

## Test plan
- [ ] `/create-pr` still produces a clean title + body for a typical small PR
- [ ] When a draft title contains conversation jargon, the gate flags it and proposes a rewrite
- [ ] Existing template-loading behavior (`PULL_REQUEST_TEMPLATE.md` etc.) still wins where a template is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)