### PR TITLE
feat(review): expand DRY rule and add reuse-over-rewrite lens

### DIFF
--- a/rules/code-review.md
+++ b/rules/code-review.md
@@ -1,8 +1,12 @@
 # Code Review Principles
 
 ## Core Principles
-- **DRY** — similar logic? Extract if maintained together, parameterize if independent
+- **DRY** — Check three forms of duplication before accepting new code:
+  1. **Within the repo** — similar logic already exists? Extract if maintained together, parameterize if independent.
+  2. **Against installed packages** — does a dependency in `package.json` / `requirements.txt` / `go.mod` / equivalent already provide this? Reimplementing utilities from a shipped library or internal shared package is `[minor]` — or `[major]` if the reimplementation drifts from documented behavior the library has already gotten right.
+  3. **Against language built-ins** — modern stdlib often covers what looks custom (`Object.groupBy`, `Array.prototype.flatMap`, `itertools.groupby`, etc.). Flag custom helpers that duplicate built-ins.
 - **Consistency** — follow existing patterns and conventions (grep for similar files to find them)
+- **Modeling** — logic lives in the right module/package/class; signatures match neighbors; new code is placed where a future reader would look for it
 - **Test quality** — tests should not silently pass (always-green tests are noise); data should match types
 
 ## Scoring

--- a/skills/review/references/code-quality.md
+++ b/skills/review/references/code-quality.md
@@ -27,14 +27,19 @@ Wrap Claude's built-in `/review` in a repo-standard loop:
    - **Committed mode** (`--committed` or when invoked on already-committed changes): `git diff <base>..HEAD`. Skip stage/commit steps in the calling workflow.
    - Apply any explicit path filtering.
 2. Perform a code review using the criteria in `rules/code-review.md`. Read each changed file, examine the diff, and assess against the scoring framework and severity tags.
-3. Classify findings as `[major]`, `[minor]`, or `[nitpick]`.
-4. For bug-fix reviews: grep the codebase for the same pattern that caused the bug (e.g., if the fix changed `e.target` to `e.currentTarget`, search for other occurrences of the broken pattern). Report matches as findings.
-5. **Check test coverage for changed behavior.** For each changed file that introduces or modifies behavior, verify that a corresponding test exists. Missing tests are a `[major]` finding. This applies to the original diff **and** to any fixes made during this review loop — if you fix code in step 6, that fix also needs test coverage. Exception: if the test gap is explicitly tracked as a follow-up in PROJECT.md with a clear plan and owner, note it in the summary's Remaining section instead of classifying it as a finding.
+3. **DRY + modeling check.** For any new helper, utility, or non-trivial logic introduced in the diff:
+   - Check the dependency manifest (`package.json`, `requirements.txt`, `pyproject.toml`, `go.mod`, etc.) for a library that already provides this. Flag reimplementations of installed packages as `[minor]` (or `[major]` if the reimplementation has bugs the library has already fixed).
+   - Grep the repo for sibling implementations of the same logic. Flag duplication and propose extraction or reuse.
+   - **Reuse over rewrite**: for any new function, ask whether an existing function in the repo or an installed dependency could have been called, wrapped, or extended instead. Flag fresh implementations of partially-overlapping logic as `[minor]` even when there's no exact duplication — composition is preferred over parallel implementations that drift over time.
+   - Verify placement: is this logic in the module/package/class where a future reader would look for it, with a signature that matches its neighbors? Misplaced or oddly-shaped code is `[minor]` even if it's correct in isolation.
+4. Classify findings as `[major]`, `[minor]`, or `[nitpick]`.
+5. For bug-fix reviews: grep the codebase for the same pattern that caused the bug (e.g., if the fix changed `e.target` to `e.currentTarget`, search for other occurrences of the broken pattern). Report matches as findings.
+6. **Check test coverage for changed behavior.** For each changed file that introduces or modifies behavior, verify that a corresponding test exists. Missing tests are a `[major]` finding. This applies to the original diff **and** to any fixes made during this review loop — if you fix code in step 7, that fix also needs test coverage. Exception: if the test gap is explicitly tracked as a follow-up in PROJECT.md with a clear plan and owner, note it in the summary's Remaining section instead of classifying it as a finding.
    - **No tests found for changed logic**: After flagging as `[major]`, trigger the test suggestion reviewer (`testing/references/review-testplan.md`) to recommend specific tests to write.
    - **Tests found**: Trigger the test quality reviewer (`testing/references/review-tests.md`) to evaluate whether they catch regressions, plus test suggestions for additional coverage.
-6. Fix all `[major]` and `[minor]` items directly — including adding tests for uncovered behavior.
-7. Re-run targeted tests after each fix to catch regressions.
-8. Re-run review on the changed files — including files you just fixed and tests you just added. Review your own fix as if someone else wrote it: check error paths, async ordering, state consistency, and boundary conditions. The re-review is not a formality.
+7. Fix all `[major]` and `[minor]` items directly — including adding tests for uncovered behavior.
+8. Re-run targeted tests after each fix to catch regressions.
+9. Re-run review on the changed files — including files you just fixed and tests you just added. Review your own fix as if someone else wrote it: check error paths, async ordering, state consistency, and boundary conditions. The re-review is not a formality.
 
 ## Stop Rules
 


### PR DESCRIPTION
## Summary
- Strengthen the DRY rule in `rules/code-review.md` to explicitly cover three forms: within-repo duplication, reimplementing installed packages, and reinventing language built-ins. Add a **Modeling** principle covering placement and signature consistency.
- Add an explicit **DRY + modeling check** step to `skills/review/references/code-quality.md` so the always-on code-quality lens performs concrete actions: read the dependency manifest, grep for siblings, look for reuse-over-rewrite opportunities (composition over parallel implementations), and verify placement.

## Why
Compared the toolkit's review flow against a single-shot Codex review prompt and found one real gap: we lacked an explicit "did this PR reimplement something an installed dependency already provides" check. We also covered duplication (DRY) but not the adjacent "could this new function have built on / wrapped an existing one" reuse-bias question. Both are now operationalized as concrete review actions rather than aspirational principles.

## Test plan
- [ ] Run `/review-code` against a diff that introduces a new utility duplicating a `package.json` dependency — verify the dep reimplementation is flagged
- [ ] Run `/review-code` against a diff that adds a fresh function partially overlapping with an existing one — verify reuse-over-rewrite is flagged as `[minor]`
- [ ] Confirm step renumbering in `code-quality.md` is internally consistent (cross-references to "step N" updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)