### PR TITLE
feat(toolkit): tighten workflow defaults — per-cherry push, PROJECT.md gates, pre-push hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,11 @@ ai-toolkit/
 │   └── workstreams/         # Post-parallel-implementation fan-in and merge sequencing
 ├── hooks/
 │   ├── prevent-project-commit.sh  # Block unsafe git flags and local workflow state commits
-│   ├── test-prevent-project-commit.sh # Smoke tests for git safety hook behavior
+│   ├── pre-push-validate.sh       # Run repo-pinned ruff + targeted pytest on commits about to be pushed
 │   ├── check-resources.sh         # Warn on constrained resources before tests
 │   ├── check-plan-drift.sh        # Warn at turn end when PLAN.md outpaces PROJECT.md
-│   └── agent-setup-edit-reminder.sh # Remind to load agent-setup-maintainer on agent-setup edits
+│   ├── agent-setup-edit-reminder.sh # Remind to load agent-setup-maintainer on agent-setup edits
+│   └── test-prevent-project-commit.sh # Smoke tests for the git safety hook (not a productive hook)
 ├── extensions/
 │   └── pgm/                 # Program management (optional, install with --with-pgm)
 │       ├── commands/         # /create-status-report, /create-velocity-report

--- a/commands/address-feedback.md
+++ b/commands/address-feedback.md
@@ -13,7 +13,7 @@
 /address-feedback <pr-number-or-url> --auto
 ```
 
-`--auto` skips triage/posting confirmations where verification is clean. It does not authorize commit, amend, rebase, push, or force-push by itself.
+`--auto` skips triage/posting confirmations entirely (no per-step prompts). Without `--auto`, the default flow still creates new commits, pushes them to the current PR branch, posts replies to bot threads, and resolves eligible bot threads — but pauses for amend/rebase/force-push, human-thread wording, and final approval/request-changes. `--auto` removes those pauses for bot/posting work only; it does NOT authorize amend, rebase, or force-push.
 
 ## Routing
 
@@ -56,8 +56,8 @@ For STANDARD work, emit the Phase Plan block from `rules/complexity-gate.md` imm
 - Pause after triage unless `--auto` was passed.
 - Run `/verify` or equivalent pre-flight checks before `/review-code`, and record the result in the Review Gate.
 - Use the Review Gate skip/micro-fix exceptions only when `rules/review-gate.md` allows them; otherwise run `/review-code` after substantive fixes.
-- Stop before posting when `--draft` was passed, a discussion needs user wording, verification failed, the fix is not visible on the PR branch, or push/post safety is unclear.
-- Stop before commit, amend, rebase, push, force-push, GitHub posting, or thread resolution unless the user explicitly authorized that boundary or the command flag clearly grants it.
+- Default action: create a new commit on the current PR branch, push it, post replies to bot threads, and resolve eligible bot threads once the underlying fix is verified.
+- Pause for explicit user confirmation when any of these apply: `--draft` was passed, a human-thread reply needs user wording, verification failed, the fix is not yet visible on the PR branch, the next git step would amend/rebase/force-push, the push target is ambiguous (not the current PR branch, or tracks an unexpected remote), or the next action would approve / request changes on the PR.
 - Run the PII scrub from `feedback/references/reply-resolve.md` over every drafted reply, top-level comment, and commit message before posting or pushing. Strip customer names, internal ticket IDs (Shortcut/Linear/Jira), internal URLs, reporter identity, and credentials.
 
 ## Summary Contract

--- a/commands/create-feature.md
+++ b/commands/create-feature.md
@@ -31,6 +31,7 @@ The command owns the visible gates and sequence. Each step loads only the refere
 - For STANDARD work, follow `rules/context-management.md`: checkpoint/clear after `PLAN.md` is written, after plan review/action gate accepts, after each implementation slice or wave, and after code review fixes when validation/PR work remains.
 - For STANDARD work, emit the Phase Plan block from `rules/complexity-gate.md` immediately after the Complexity Gate.
 - **`## Slice N Complete` PROJECT.md write is a hard gate** before every per-slice checkpoint/clear on the STANDARD path. No clear without the entry.
+- **`## Feature Complete` PROJECT.md write is a hard gate** before the chat summary on every path. TRIVIAL/MODERATE single-shot runs need this so `/clear` or `/archive-project-file` after `/create-feature` does not lose the result. STANDARD runs that ended with a per-slice entry must still emit the rollup before the summary. See the end-of-workflow section below.
 
 ## Planning Phase Boundary
 
@@ -129,3 +130,33 @@ Use the happy paths and path rules as the primary flow. Use this table as a phas
 - **Standard**: use the planning phase for exploration/design only; write `PLAN.md`; run plan review and action gate; then implement in slices.
 
 For 3+ independent slices, treat the work as STANDARD with workstreams and keep the main thread as a thin orchestrator. `PLAN.md` owns the slice table, dependencies, entrance/exit criteria, and acceptance checks. PROJECT.md records only the active slice/wave and next action. Load `rules/orchestration.md` only when deciding subagent batch size, workstream fan-in, or reasoning effort.
+
+## End-of-Workflow PROJECT.md Update (Hard Gate)
+
+Before emitting the chat summary, append a `## Feature Complete` entry to PROJECT.md so the durable record survives `/clear` or `/archive-project-file`. Required on every path — TRIVIAL/MODERATE single-shot runs included.
+
+Minimum entry shape:
+
+```markdown
+## Feature Complete
+Feature: [one-line description or ticket]
+Slices delivered: [count, or "single-shot"]
+Files changed: [summary or count]
+Tests added/updated: [list or count]
+Verification: [strength label]
+Review Gate: [status]
+Feature validation: [pass / fail / skipped — reason] (if applicable)
+Residual risk: [one-liner, or "none"]
+PR: [URL or "no PR yet"]
+```
+
+For STANDARD runs that already wrote per-slice `## Slice N Complete` entries, this rollup summarizes the run; it does not replace those entries.
+
+Emit before the chat summary:
+
+```markdown
+## PROJECT.md Updated — Feature Complete
+Entry recorded
+```
+
+Do not emit the chat summary until the `## PROJECT.md Updated — Feature Complete` confirmation block has been emitted.

--- a/commands/create-pr.md
+++ b/commands/create-pr.md
@@ -124,7 +124,31 @@ gh pr create --title "..." --body "..." [--draft] [--base ...]
 
 Return the PR URL.
 
-### 8. Summary
+### 8. PROJECT.md Update (Hard Gate)
+
+Before emitting the chat summary, append a `## PR Created` entry to PROJECT.md so the project state reflects the new PR. Without this write, `/clear` or `/archive-project-file` immediately after `/create-pr` loses the PR pointer and the next session has no record that the PR exists.
+
+```markdown
+## PR Created
+PR #[number]: [title]
+URL: [link]
+Base: [base] ← [head branch]
+Commits: [N]
+Draft: [yes/no]
+```
+
+If a prior phase (`/create-feature`, `/fix-bug`, etc.) has an open entry in PROJECT.md whose work this PR ships, mark that entry resolved in the same write rather than leaving it dangling.
+
+Emit before the chat summary:
+
+```markdown
+## PROJECT.md Updated — PR Created
+PR #[number] recorded; prior phase entry: [resolved / none / kept]
+```
+
+### 9. Summary
+
+Do not emit this summary until the `## PROJECT.md Updated — PR Created` confirmation block has been emitted.
 
 ```markdown
 ## Create-PR Complete

--- a/commands/create-tests.md
+++ b/commands/create-tests.md
@@ -77,4 +77,20 @@
 - Favor the smallest set of high-signal tests over broad test quantity
 - `/review-code` is an internal phase here, not the expected next top-level user step
 - Stop before committing unless the user explicitly requested commit/push behavior.
-- TRIVIAL runs (one or two tests) skip the PROJECT.md hard gates; MODERATE runs update PROJECT.md once at the end; STANDARD/expensive runs follow the hard-gate cadence in the Command Contract.
+- Every run writes at least a one-line `## Tests Created` entry to PROJECT.md before the chat summary so `/clear` or `/archive-project-file` after `/create-tests` does not lose the record. TRIVIAL/MODERATE runs satisfy this with a single end-of-run entry; STANDARD/expensive runs follow the hard-gate cadence in the Command Contract.
+
+  Minimum entry shape for TRIVIAL/MODERATE:
+
+  ```markdown
+  ## Tests Created
+  Files: [list]
+  Behaviors covered: [one-liner]
+  Verification: [strength label]
+  ```
+
+  Emit before the chat summary:
+
+  ```markdown
+  ## PROJECT.md Updated — Tests Created
+  Files recorded: [count]
+  ```

--- a/commands/fix-bug.md
+++ b/commands/fix-bug.md
@@ -28,10 +28,12 @@ The command owns the visible gates and sequence. Each step loads only the refere
 - For STANDARD work, run plan-review iteration on `PLAN.md` via `skills/planning/references/iterate-review.md` after `PLAN.md Written` and before implementation; require the reviewer threshold and cold-read Go documented in that helper.
 - Run `/verify` or equivalent pre-flight checks before `/review-code`, and record the result in the Review Gate.
 - Do not commit without an added or updated regression test unless the gap is explicitly accepted.
+- Default action when verification is STRONG, a regression test was added or updated (or the gap was explicitly accepted by the user), and the Review Gate is clean: create a new commit on the current feature branch and push it as part of the fix flow. The TDD regression test is the verification gate that makes auto-push safe — without it, pause. Pause for amend, rebase, force-push, ambiguous push target (not the current feature branch, or tracks an unexpected remote), PARTIAL/WEAK verification, or any STANDARD-path hold (RCA review, plan review, per-slice gates).
 - Only the main thread writes PROJECT.md or `PLAN.md`. Subagents return handoffs; the orchestrator updates durable state.
 - For STANDARD or expensive bug work, follow `rules/context-management.md`: checkpoint/clear after RCA review accepts, after `PLAN.md` is written, after plan review accepts, after implementation, and after code review fixes when QA/PR work remains.
 - For STANDARD work, emit the Phase Plan block from `rules/complexity-gate.md` immediately after the Complexity Gate.
 - **`## Slice N Complete` PROJECT.md write is a hard gate** before every per-slice checkpoint/clear on the STANDARD path. Block shape matches `commands/create-feature.md` step 8. No clear without the entry.
+- **`## Bug Fix Complete` PROJECT.md write is a hard gate** before the chat summary on every path. TRIVIAL/MODERATE single-shot runs need this so `/clear` or `/archive-project-file` after `/fix-bug` does not lose the result. STANDARD runs that ended with a per-slice entry must still emit the rollup before the summary. See the end-of-workflow section below.
 
 ## Planning Phase Boundary
 
@@ -95,3 +97,33 @@ Use the happy paths and path rules as the primary flow. Use this table as a phas
 For multiple plausible causes, use bounded investigation lanes only when they save context or real time. Do not start the next lane wave while a current lane has unresolved blockers, conflicting evidence, or a user decision.
 
 If the existing fix status is `FIXED_UPSTREAM`, route to `/cherry-pick`. If it is `FIX_PENDING_PR`, stop and surface adopt/monitor/supersede choices.
+
+## End-of-Workflow PROJECT.md Update (Hard Gate)
+
+Before emitting the chat summary, append a `## Bug Fix Complete` entry to PROJECT.md so the durable record survives `/clear` or `/archive-project-file`. Required on every path — TRIVIAL/MODERATE single-shot runs included.
+
+Minimum entry shape:
+
+```markdown
+## Bug Fix Complete
+Bug: [one-line description or ticket]
+Root cause: [one-liner]
+Files changed: [list]
+Regression test: [added / updated / accepted gap with reason]
+Verification: [strength label]
+Review Gate: [status]
+QA: [pass / fail / skipped — reason] (if applicable)
+Residual risk: [one-liner, or "none"]
+Commit: [SHA or "no commit"]
+```
+
+For STANDARD runs that already wrote per-slice `## Slice N Complete` entries, this rollup summarizes the run; it does not replace those entries.
+
+Emit before the chat summary:
+
+```markdown
+## PROJECT.md Updated — Bug Fix Complete
+Entry recorded
+```
+
+Do not emit the chat summary until the `## PROJECT.md Updated — Bug Fix Complete` confirmation block has been emitted.

--- a/commands/fix-ci.md
+++ b/commands/fix-ci.md
@@ -24,7 +24,7 @@
 - Run local verification before review, and emit a Review Gate block whenever repo-tracked files changed.
 - Update PROJECT.md at standard-path boundaries. Two updates are **hard gates with confirmation blocks** on every path: initial-triage entry before path branching (step 3 tail), Completed entry before the chat summary (step 9 head).
 - The main thread owns `CI_FIX.md` and PROJECT.md. Subagents return compact handoffs; they do not update durable state directly.
-- Do not commit, amend, rebase, push, or force-push unless the user explicitly authorized that git boundary for this run.
+- When verification is STRONG and the fix is approved, create a new commit on the current feature branch and push it as part of the fix flow. Pause for amend, rebase, or force-push, and when the push target is ambiguous (not the current feature branch, or tracks an unexpected remote). PARTIAL/WEAK verification and standard-path holds stay non-committing — present the diagnosis and stop.
 - For STANDARD or expensive CI work, checkpoint/clear after `CI_FIX.md` or PROJECT.md captures classification/grouping, after Action Gate/RCA decisions, after local verification, and after `/review-code` when commit recommendation work remains.
 
 ## Happy Paths
@@ -91,7 +91,7 @@ For zero-logic diffs, apply the skip rule from `rules/review-gate.md`. For true 
 
 Use the commit recommendation strategy in [skills/debug/references/ci-fix-orchestration.md](../skills/debug/references/ci-fix-orchestration.md).
 
-Do not commit standard-path or PARTIAL/WEAK fixes automatically. Do not commit, amend, rebase, push, or force-push any fix unless the user explicitly authorized that git boundary for this run. Present the diagnosis, verification gap, and recommended next action.
+Do not commit standard-path or PARTIAL/WEAK fixes automatically. For STRONG-verified trivial/moderate fixes with a clean Review Gate, create a new commit on the current feature branch and push it. Pause for amend, rebase, or force-push, and when the push target is ambiguous. For PARTIAL/WEAK or standard-path holds, present the diagnosis, verification gap, and recommended next action without committing.
 
 ### 9. Summary + Metrics
 

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -29,6 +29,7 @@ Use `--draft` to show the review locally without posting. Use `--auto` to skip c
 - Post only clean, user-confirmed finding text to GitHub.
 - For batch reviews, keep the main thread as a thin orchestrator and use compact per-PR handoffs.
 - For batch reviews of 4+ PRs, follow `rules/context-management.md`: after each wave of 3 PRs, the main thread must append a `## Review-PR Batch Wave N` block to PROJECT.md (per-PR recommendation, posted status, top finding, residual risk), then `/checkpoint --clear` before launching the next wave. This is a hard gate — without the PROJECT.md write, the per-PR posting state is lost on clear.
+- For every reviewed PR (single or batch), append a `## PR Review — #N` entry to PROJECT.md before the chat summary. This is a hard gate so `/clear` or `/archive-project-file` immediately after `/review-pr` does not lose the review record.
 
 ## Steps
 
@@ -65,7 +66,31 @@ Respect:
 - clean Standard reviews: confirm before approving unless `--auto`
 - findings: post only user-confirmed finding descriptions
 
-### 4. Summary
+### 4. PROJECT.md Update (Hard Gate)
+
+Before emitting the chat summary, append a `## PR Review — #N` entry per reviewed PR to PROJECT.md:
+
+```markdown
+## PR Review — #[number]
+Verdict: [approve / request-changes / comment]
+Top finding: [one-liner, or "none"]
+Severity counts: [critical N, major N, minor N, nit N]
+Posted: [yes / draft / no — reason]
+Residual risk: [one-liner, or "none"]
+```
+
+Batch waves already write `## Review-PR Batch Wave N`; the per-PR entries can be folded into that wave block instead of duplicated.
+
+Emit before the chat summary:
+
+```markdown
+## PROJECT.md Updated — PR Review(s)
+PRs recorded: [#numbers]
+```
+
+### 5. Summary
+
+Do not emit the chat summary until the `## PROJECT.md Updated — PR Review(s)` block has been emitted.
 
 Emit the summary from [skills/review/references/pr-posting.md](../skills/review/references/pr-posting.md).
 
@@ -78,6 +103,7 @@ Emit the summary from [skills/review/references/pr-posting.md](../skills/review/
 - [ ] All findings tagged by severity
 - [ ] Recommendation determined before posting
 - [ ] Posting action respects `--draft`, `--auto`, and user-confirmation boundaries
+- [ ] PROJECT.md `## PR Review — #N` entry written for every reviewed PR before summary
 - [ ] Summary emitted
 
 ## Notes

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -26,6 +26,7 @@ Use `--draft` to show the review locally without posting. Use `--auto` to skip c
 - Assess impact before calibrating severity.
 - Validate PR premise for Standard or CORE-impact PRs.
 - Show findings and severity reasoning to the user before posting unless `--auto` is passed.
+- Run the PII scrub from `feedback/references/reply-resolve.md` over every drafted finding, top-level comment, and review summary before posting. Strip customer names, internal ticket IDs (Shortcut/Linear/Jira), internal URLs, reporter identity, and credentials. Reviewer findings often quote diff context — that quoted context is the most common PII leak surface.
 - Post only clean, user-confirmed finding text to GitHub.
 - For batch reviews, keep the main thread as a thin orchestrator and use compact per-PR handoffs.
 - For batch reviews of 4+ PRs, follow `rules/context-management.md`: after each wave of 3 PRs, the main thread must append a `## Review-PR Batch Wave N` block to PROJECT.md (per-PR recommendation, posted status, top finding, residual risk), then `/checkpoint --clear` before launching the next wave. This is a hard gate — without the PROJECT.md write, the per-PR posting state is lost on clear.
@@ -103,6 +104,7 @@ Emit the summary from [skills/review/references/pr-posting.md](../skills/review/
 - [ ] All findings tagged by severity
 - [ ] Recommendation determined before posting
 - [ ] Posting action respects `--draft`, `--auto`, and user-confirmation boundaries
+- [ ] PII scrub run over all drafted findings, top-level comments, and review summaries before posting
 - [ ] PROJECT.md `## PR Review — #N` entry written for every reviewed PR before summary
 - [ ] Summary emitted
 

--- a/commands/run-test-plan.md
+++ b/commands/run-test-plan.md
@@ -25,6 +25,24 @@
   - After step 6 (report): `## Test Plan Reported` (where posted: Shortcut story link, PR comment, or local only).
 - These writes are **hard gates before any `/checkpoint --clear`** on STANDARD/expensive runs — chat-only scenario state is unrecoverable after clear.
 - The plan matrix and per-scenario evidence paths must land in PROJECT.md before clear regardless of whether the run is reactive or proactive checkpoint.
+- **Every run** (including TRIVIAL/MODERATE) writes at least a `## Test Plan Results` entry to PROJECT.md before the chat summary so `/clear` or `/archive-project-file` after `/run-test-plan` does not lose the QA record. TRIVIAL/MODERATE runs may fold plan + results + report into a single end-of-run entry; STANDARD/expensive runs follow the per-phase cadence above.
+
+  Minimum entry shape for TRIVIAL/MODERATE:
+
+  ```markdown
+  ## Test Plan Results
+  Source: [plan path / Shortcut / PR / area]
+  Scenarios: [N run, N passed, N failed, N blocked, N skipped]
+  Evidence: [recording path or "none"]
+  Reported: [link or "local only"]
+  ```
+
+  Emit before the chat summary:
+
+  ```markdown
+  ## PROJECT.md Updated — Test Plan Results
+  Scenarios recorded: [count]
+  ```
 
 ## Steps
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -22,6 +22,8 @@ It restores workflow state from PROJECT.md rather than relying on chat memory.
    - If found: Read completely
    - If not found anywhere: Ask if user wants to create one using `PROJECT_TEMPLATE.md`
 
+   **If PROJECT.md is a symlink, resolve it before writing.** Claude Code's Write/Edit refuses to write through symlinks. Run `readlink -f <path-to-PROJECT.md>` to get the real target, then Read and Write/Edit that resolved path when adding the session entry or any later updates in this session. Reads through the symlink are fine; only writes require the resolved path. This same rule applies to PLAN.md and any other toolkit-managed file in the working directory.
+
 2. **Check for Continuation Checkpoint**
 
    If PROJECT.md contains a `## Continuation Checkpoint` section:

--- a/commands/test-pr.md
+++ b/commands/test-pr.md
@@ -40,13 +40,33 @@ The main thread owns PR identity, app URL, scenario selection, evidence paths, p
 
 ## PROJECT.md Discipline
 
+**Every run** writes at least one entry to PROJECT.md before the chat summary, so `/clear` or `/archive-project-file` immediately after `/test-pr` does not lose the QA record.
+
 For STANDARD or expensive runs (CORE impact, broad scenario set, repeated re-validation), follow `rules/context-management.md` and write durable state to PROJECT.md at each phase boundary before `/checkpoint --clear`:
 
 - After scenario selection: `## Test-PR Scenarios` (PR identity, app URL, impact tier, scenario list).
 - After execution: `## Test-PR Results` (per-scenario result, evidence paths, recording path).
 - After posting: `## Test-PR Posted` (Shortcut/PR comment link or "local only").
 
-These writes are **hard gates before any `/checkpoint --clear`** on STANDARD/expensive runs. Smoke runs (`--smoke`) typically stay TRIVIAL/MODERATE and skip the hard gates.
+These writes are **hard gates before any `/checkpoint --clear`** on STANDARD/expensive runs.
+
+For TRIVIAL/MODERATE runs (including `--smoke`), a single `## Test-PR Results` entry at completion is the minimum:
+
+```markdown
+## Test-PR Results — PR #[number]
+App: [url]
+Impact: [tier]
+Scenarios: [N run, N passed, N failed]
+Evidence: [recording path or "none"]
+Posted: [link or "local only"]
+```
+
+Emit before the chat summary:
+
+```markdown
+## PROJECT.md Updated — Test-PR Results
+PR #[number] recorded
+```
 
 ## Gates
 
@@ -58,6 +78,8 @@ These writes are **hard gates before any `/checkpoint --clear`** on STANDARD/exp
 - Stop before posting unless `--post` was passed and evidence paths are available.
 
 ## Summary Contract
+
+Do not emit the chat summary until the `## PROJECT.md Updated — Test-PR Results` confirmation block has been emitted.
 
 End with:
 

--- a/commands/update-tests.md
+++ b/commands/update-tests.md
@@ -134,4 +134,21 @@
 - Favor replacing low-signal tests over adding redundant ones
 - Write the failing test first when feasible; if blocked, document why before changing the suite
 - `/review-code` is an internal phase here, not the expected next top-level user step
-- TRIVIAL runs (single tiny test fix) skip the PROJECT.md hard gates; MODERATE runs update PROJECT.md once at the end; STANDARD/expensive runs follow the hard-gate cadence in the Command Contract.
+- Every run writes at least a one-line `## Tests Updated` entry to PROJECT.md before the chat summary so `/clear` or `/archive-project-file` after `/update-tests` does not lose the record. TRIVIAL/MODERATE runs satisfy this with a single end-of-run entry; STANDARD/expensive runs follow the hard-gate cadence in the Command Contract.
+
+  Minimum entry shape for TRIVIAL/MODERATE:
+
+  ```markdown
+  ## Tests Updated
+  Files: [list]
+  Change: [one-liner — what behavior changed or got covered]
+  Verification: [strength label]
+  Commit: [SHA or "no commit"]
+  ```
+
+  Emit before the chat summary:
+
+  ```markdown
+  ## PROJECT.md Updated — Tests Updated
+  Files recorded: [count]
+  ```

--- a/hooks/pre-push-validate.sh
+++ b/hooks/pre-push-validate.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+#
+# pre-push-validate.sh — Claude Code PreToolUse hook
+#
+# Runs lint + targeted tests on the commits that are about to be pushed,
+# using the repo's pinned tool versions (not the system's). Blocks the push
+# only on hard failures. Fail-open on any unexpected error.
+#
+# Tiers:
+#   1. pre-commit on all changed files (preferred — runs the repo's full
+#      pinned hook set: ruff, mypy, prettier, oxlint, eslint, tsc, etc.).
+#      Fallback for repos without .pre-commit-config.yaml or `pre-commit`:
+#      ruff on changed *.py files via repo venv > uv run > skip.
+#   2. pytest on changed test files, time-boxed via the repo's venv
+#
+# Bypass:
+#   - Prefix the command:           SKIP_PRECHECK=1 git push ...
+#   - Env at Claude Code start:     SKIP_PRECHECK=1
+#
+# Exit codes:
+#   0 — allow
+#   2 — block (validation failed, message printed to stderr)
+#
+
+set -uo pipefail
+
+# Fail open on any unexpected error
+trap 'exit 0' ERR
+
+INPUT=$(cat)
+
+command -v jq      >/dev/null 2>&1 || exit 0
+command -v git     >/dev/null 2>&1 || exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+CWD=$(echo     "$INPUT" | jq -r '.cwd // empty'                2>/dev/null) || exit 0
+
+[[ -z "$COMMAND" || -z "$CWD" ]] && exit 0
+[[ ! -d "$CWD" ]] && exit 0
+
+# Fast-exit if this isn't a `git push`. Keeps every other Bash call cheap.
+# Conservative match: word-boundary git, then push as a later token. The
+# safety hook (prevent-project-commit.sh) already handles obfuscated forms.
+if ! echo "$COMMAND" | grep -Eq '(^|[^[:alnum:]_/-])git([[:space:]]+(-[^[:space:]]+|-c[[:space:]]+[^[:space:]]+|-C[[:space:]]+[^[:space:]]+))*[[:space:]]+push([[:space:]]|$)'; then
+    exit 0
+fi
+
+# Bypass — explicit user opt-out
+if [[ -n "${SKIP_PRECHECK:-}" ]] || echo "$COMMAND" | grep -q 'SKIP_PRECHECK=1'; then
+    exit 0
+fi
+
+# Must be inside a git repo
+GIT_DIR=$(git -C "$CWD" rev-parse --git-dir 2>/dev/null) || exit 0
+REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Determine which commits will be pushed.
+# Prefer upstream tracking; otherwise compare against origin/main or main.
+UPSTREAM=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+if [[ -n "$UPSTREAM" ]]; then
+    RANGE="$UPSTREAM..HEAD"
+else
+    BASE=""
+    for ref in origin/main origin/master main master; do
+        BASE=$(git -C "$REPO_ROOT" merge-base HEAD "$ref" 2>/dev/null) && break || BASE=""
+    done
+    [[ -z "$BASE" ]] && exit 0
+    RANGE="$BASE..HEAD"
+fi
+
+# Changed files (added/copied/modified/renamed), still present on disk
+CHANGED=$(git -C "$REPO_ROOT" diff --name-only --diff-filter=ACMR "$RANGE" 2>/dev/null | \
+    while IFS= read -r f; do [[ -f "$REPO_ROOT/$f" ]] && echo "$f"; done)
+
+[[ -z "$CHANGED" ]] && exit 0
+
+# Filter sets
+PY_FILES=$(echo "$CHANGED" | grep -E '\.py$' || true)
+TEST_FILES=$(echo "$CHANGED" | grep -E '(^|/)test_[^/]+\.py$|(^|/)tests?/.*\.py$|.*_test\.py$' || true)
+
+# Convert newlines to space-separated args for tool invocations
+files_args() {
+    echo "$1" | tr '\n' ' '
+}
+
+FAILURES=""
+WARNINGS=""
+
+# ── Tier 1: lint/format/type-check via the repo's pinned hooks ──────────────
+#
+# Returns:
+#   0  — ran and passed (or nothing to do)
+#   1  — ran and failed (block the push)
+#   99 — not configured here, caller should try the fallback path
+run_precommit() {
+    local files="$1"
+    [[ -z "$files" ]] && return 0
+
+    cd "$REPO_ROOT" || return 99
+    [[ -f .pre-commit-config.yaml ]] || return 99
+    command -v pre-commit >/dev/null 2>&1 || {
+        WARNINGS+=$'\n  - pre-commit config present but `pre-commit` not installed — install it so push-time lint matches CI.'
+        return 99
+    }
+
+    local args; args=$(files_args "$files")
+    local timeout_cmd=""
+    command -v gtimeout >/dev/null 2>&1 && timeout_cmd="gtimeout 240"
+
+    # `--files` makes pre-commit operate on these files regardless of stage
+    # gating. Each hook's own `files:` regex filters down further, so hooks
+    # that don't match the changed set no-op. Exit 1 covers both "hook
+    # failed" and "hook modified files" — both should block the push.
+    # shellcheck disable=SC2086
+    $timeout_cmd pre-commit run --files $args >&2
+    local rc=$?
+
+    if [[ $rc -eq 124 ]]; then
+        WARNINGS+=$'\n  - pre-commit: exceeded 240s — not blocking, run locally to verify.'
+        return 0
+    fi
+    return $rc
+}
+
+# ── Tier 1 fallback: ruff on changed Python files (only when pre-commit is
+#    not configured for this repo). ──────────────────────────────────────────
+run_ruff_fallback() {
+    local files="$1"
+    [[ -z "$files" ]] && return 0
+
+    cd "$REPO_ROOT" || return 0
+
+    for ruff_bin in .venv/bin/ruff venv/bin/ruff; do
+        if [[ -x "$ruff_bin" ]]; then
+            local args; args=$(files_args "$files")
+            # shellcheck disable=SC2086
+            "$ruff_bin" check $args >&2 || return 1
+            return 0
+        fi
+    done
+
+    if command -v uv >/dev/null 2>&1 && [[ -f pyproject.toml ]]; then
+        local args; args=$(files_args "$files")
+        # shellcheck disable=SC2086
+        uv run --no-sync --quiet ruff check $args >&2 || return 1
+        return 0
+    fi
+
+    WARNINGS+=$'\n  - ruff: no pinned version available (no pre-commit config, no .venv, no uv). System ruff skipped to avoid version drift.'
+    return 0
+}
+
+if [[ -n "$CHANGED" ]]; then
+    n_changed=$(echo "$CHANGED" | wc -l | tr -d ' ')
+    echo "[pre-push] pre-commit on $n_changed changed file(s)…" >&2
+    run_precommit "$CHANGED"
+    rc=$?
+    if [[ $rc -eq 99 ]]; then
+        # No pre-commit available — fall back to Python-only ruff
+        if [[ -n "$PY_FILES" ]]; then
+            n_py=$(echo "$PY_FILES" | wc -l | tr -d ' ')
+            echo "[pre-push] ruff fallback on $n_py changed Python file(s)…" >&2
+            if ! run_ruff_fallback "$PY_FILES"; then
+                FAILURES+=$'\n  - ruff failed on changed Python files'
+            fi
+        fi
+    elif [[ $rc -ne 0 ]]; then
+        FAILURES+=$'\n  - pre-commit failed on changed files (lint/format/type-check). If it modified files, commit the result and retry.'
+    fi
+fi
+
+# ── Tier 2: pytest on changed test files ────────────────────────────────────
+run_pytest() {
+    local files="$1"
+    [[ -z "$files" ]] && return 0
+
+    cd "$REPO_ROOT" || return 0
+
+    local pytest_cmd=""
+    for p in .venv/bin/pytest venv/bin/pytest; do
+        if [[ -x "$p" ]]; then
+            pytest_cmd="$p"
+            break
+        fi
+    done
+    if [[ -z "$pytest_cmd" ]] && command -v uv >/dev/null 2>&1 && [[ -f pyproject.toml ]]; then
+        pytest_cmd="uv run --no-sync --quiet pytest"
+    fi
+    if [[ -z "$pytest_cmd" ]]; then
+        WARNINGS+=$'\n  - pytest: no repo-pinned pytest found, skipping test-file run'
+        return 0
+    fi
+
+    local args; args=$(files_args "$files")
+    local timeout_cmd=""
+    command -v gtimeout >/dev/null 2>&1 && timeout_cmd="gtimeout 120"
+
+    # shellcheck disable=SC2086
+    $timeout_cmd $pytest_cmd -x --no-header -q $args >&2
+    local rc=$?
+    if [[ $rc -eq 124 ]]; then
+        WARNINGS+=$'\n  - pytest: changed test files exceeded 120s — not blocking, verify locally'
+        return 0
+    fi
+    return $rc
+}
+
+if [[ -n "$TEST_FILES" ]]; then
+    echo "[pre-push] pytest on $(echo "$TEST_FILES" | wc -l | tr -d ' ') changed test file(s)…" >&2
+    if ! run_pytest "$TEST_FILES"; then
+        FAILURES+=$'\n  - pytest failed on changed test files'
+    fi
+fi
+
+# ── Decision ────────────────────────────────────────────────────────────────
+if [[ -n "$FAILURES" ]]; then
+    {
+        echo ""
+        echo "BLOCKED: pre-push validation failed:$FAILURES"
+        if [[ -n "$WARNINGS" ]]; then
+            echo ""
+            echo "Warnings:$WARNINGS"
+        fi
+        echo ""
+        echo "Fix the failures above, or bypass for this push:"
+        echo "    SKIP_PRECHECK=1 git push ..."
+    } >&2
+    exit 2
+fi
+
+if [[ -n "$WARNINGS" ]]; then
+    {
+        echo ""
+        echo "[pre-push] passed with warnings:$WARNINGS"
+    } >&2
+fi
+
+exit 0

--- a/rules/universal.md
+++ b/rules/universal.md
@@ -9,6 +9,7 @@
 - **TDD and YAGNI** — test first, build only what's needed now
 - **End-to-end commands own their internal loops** — planning, review, and validation sub-phases should continue automatically until threshold or blocker; do not surface subcommands as the next user step unless the user explicitly chose them
 - **Update PROJECT.md before completing any workflow** — every command or ad-hoc work session that produces results must write current status, what was done, and remaining items to PROJECT.md before finishing. The formal plan lives in PLAN.md during the workflow; it persists in place after completion until the user explicitly cleans up via `/archive-project-file`. Workflows do not auto-delete files.
+- **Write through symlinks via the resolved real path** — Claude Code's Write/Edit refuses to write through a symlink (`Refusing to write through symlink: ...`). When PROJECT.md, PLAN.md, or any toolkit-managed file is a symlink (common in `.claudette`/worktree-shared-state setups), first resolve it (`readlink -f <path>`), then Read and Write/Edit the resolved real path. Reads work through symlinks unchanged.
 - **Checkpoint when context is deep** — see `rules/context-management.md` for thresholds and protocol
 - **Rules evolve from usage** — see `rules/rule-maintenance.md` for how to strengthen, update, or extract rules
 

--- a/skills/cherry-pick/SKILL.md
+++ b/skills/cherry-pick/SKILL.md
@@ -125,6 +125,18 @@ When push is not authorized, stop before publishing and record `Push: pending au
 
 The only exception is when the user explicitly asks for batched push (e.g., to reduce CI cost). In that case, confirm before deferring and record the batched-push decision.
 
+**Hard gate — per-cherry push boundary.** After step 7 passes and before any subsequent work runs (next cherry's investigate/apply, final report, checkpoint, or PR creation), the orchestrator must emit this confirmation block verbatim for *this* cherry:
+
+```markdown
+## Push Boundary — <pr-or-source-sha>
+Local SHA: <sha after validate/amend>
+Status: pushed | pending-authorization | deferred-by-user
+Remote SHA: <sha visible on remote after push> | n/a
+Reason (if not pushed): <one line>
+```
+
+If `Status: pushed`, the `git push` for this cherry has already happened — not queued, not deferred. If `Status: pending-authorization` or `deferred-by-user`, the orchestrator must also stop dependent follow-ups until the user clears the boundary. Do not start the next dependent cherry's worker without this block in chat for the previous cherry. This is the only structural defense against falling into the "apply, validate, next, …, done, push" rhythm that batches authorized pushes (see gotchas.md, "Authorized push batched at end instead of per-cherry").
+
 ## Batch Cherry-Pick Flow
 
 When multiple PRs/SHAs are provided, the main agent acts as a **thin orchestrator**. It owns ordering, dependency tracking, user decisions, checkpoint boundaries, and final synthesis. It must not accumulate raw per-cherry context.
@@ -210,6 +222,7 @@ No full diffs or long logs unless blocked. If a blocked handoff needs raw eviden
    - If a worker returns a prepared commit, branch, or patch from an isolated context, the orchestrator must replay it onto the current live target branch in planned order.
    - After replay, rerun the mandatory scope-leak audit and the minimum assigned validation on the live target branch before marking the row `Applied` or pushing.
    - Worker validation is useful evidence, but it is stale once fan-in happens; live-branch replay validation is the gate.
+   - **Hard gate before dispatching the next cherry:** the `## Push Boundary — <pr-or-sha>` block from step 8 must already be emitted in chat for the cherry that just finished. No "I'll batch the pushes at the end" path — that violates the boundary. If push is `pending-authorization` or `deferred-by-user`, stop dependent dispatch and surface to the user; only continue to *independent* picks (per the sequence plan's independence islands).
 4. **Status tracking** — record results in the execution table or `CHERRY_PICK.md`. If one fails, do NOT continue with subsequent dependent picks. Independent picks may continue.
 5. **Escalation** — surface escalations to the user, relay answers back.
 6. **Final report** — collect results and produce the document phase output. Include pushed cherries and any cherries waiting on push authorization; the report summarizes, it does not silently publish.

--- a/skills/cherry-pick/SKILL.md
+++ b/skills/cherry-pick/SKILL.md
@@ -41,7 +41,7 @@ For non-trivial or expensive cherry-picks, follow `rules/context-management.md`:
 
 ## Single Cherry-Pick Flow
 
-Each cherry-pick runs all validation phases. No validation phase may be skipped — the diff audit in step 7 is the only defense against scope leak (see gotchas.md). Step 8 is a publish boundary: run it only when `--push` or explicit user authorization grants push permission.
+Each cherry-pick runs all validation phases. No validation phase may be skipped — the diff audit in step 7 is the only defense against scope leak (see gotchas.md). Step 7c runs only when the cherry terminates as `Blocked` or `Rejected`; it surfaces the upstream PRs that would unstick the row before the final report. Step 8 is a publish boundary: run it only when `--push` or explicit user authorization grants push permission.
 
 ### 1. Investigate (heavy effort)
 
@@ -110,6 +110,16 @@ The orchestrator may not mark a cherry `Applied` without this report. If the sub
 Conflict-marker scan, **pre-commit on changed files**, build, type-check, targeted tests. Pre-commit is mandatory — conflict resolution often re-indents lines past length limits, and pre-commit is what CI runs. If pre-commit auto-fixes or you make manual fixes, `git commit --amend --no-edit` before pushing. Do not push, then amend, then force-push.
 
 → Full procedure (subagent contract, LLM audit, validation order, status labels, dependency manifest rule): [references/validate.md](references/validate.md)
+
+### 7c. Unblock Discovery (Blocked / Rejected only)
+
+When a cherry terminates as `Blocked` or `Rejected` for reasons that look like "target is missing something" (modify/delete, prerequisite commits flagged in investigate, target-side architecture missing), spawn a discovery subagent before moving to the final report. Its only job is to name the upstream PRs/commits that would unstick this cherry — it does **not** investigate, gate, plan, or apply them.
+
+Skip when the rejection is intrinsic (reject-category API rewrite, dependency-bump PR, build-system change). Record "no unblock path" on the row and continue.
+
+Mode is inform-only: surface candidates in the final report under "What to do next" so the user decides whether to add them to the run. Auto-picking is a future extension (`--auto-unblock`).
+
+→ Full subagent contract, output block, future-auto-unblock notes: [references/unblock-discovery.md](references/unblock-discovery.md)
 
 ### 8. Push Recommendation / Authorized Push
 
@@ -209,6 +219,7 @@ Each per-cherry or per-wave subagent returns only:
 - commands run
 - residual risk
 - dependency implications for later rows
+- unblock candidates (only when result is `Blocked` or `Rejected` and step 7c ran): ordered list of upstream PRs/SHAs that would unstick this row, or `none` with one-line reason
 
 No full diffs or long logs unless blocked. If a blocked handoff needs raw evidence, put file paths or the shortest decisive excerpt in the manifest.
 

--- a/skills/cherry-pick/SKILL.md
+++ b/skills/cherry-pick/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cherry-pick
 description: Cherry-pick, backport, or apply commits/PRs onto another branch with safety gates and per-change validation. Do NOT use for same-branch bug fixes, broad refactors, dependency upgrades, or general behavior rewrites.
-argument-hint: "[pr-url | sha...] [--target branch] [--force] [--plan-only] [--push]"
+argument-hint: "[pr-url | sha...] [--target branch] [--force] [--plan-only] [--no-push]"
 allowed-tools: Bash(git *) Bash(gh *) Read Grep Glob Edit
 ---
 
@@ -23,9 +23,9 @@ Read any sibling `rules.md`, `lessons.md`, and `gotchas.md` files if present. Ch
 
 If the workflow would cross a contract boundary, stop and ask — do not cross first and report after.
 
-`--push` explicitly authorizes the per-cherry push boundary. Without `--push` or explicit user authorization during the run, validate locally and stop with a push recommendation before publishing.
+Per-cherry push is the default action at step 8 — every successfully validated cherry is pushed to the target branch before the next cherry starts. `--no-push` opts out: validate locally, record `pending-authorization`, and stop before publishing. The per-cherry push boundary (step 8) and its hard-gate confirmation block still run on every cherry regardless; `--no-push` only changes whether the boundary's outcome is `pushed` or `pending-authorization`.
 
-For non-trivial or expensive cherry-picks, follow `rules/context-management.md`: checkpoint/clear after investigate/gate/plan is recorded in the execution table, and again after apply/adapt/validate when push authorization or final reporting remains. Batch runs checkpoint/clear between waves by default.
+For non-trivial or expensive cherry-picks, follow `rules/context-management.md`: checkpoint/clear after investigate/gate/plan is recorded in the execution table, and again after apply/adapt/validate when push (or, under `--no-push`, push authorization) and final reporting remain. Batch runs checkpoint/clear between waves by default.
 
 ## Usage
 
@@ -36,12 +36,12 @@ For non-trivial or expensive cherry-picks, follow `rules/context-management.md`:
 /cherry-pick <sha> --force                     # Override reject-category gate
 /cherry-pick <sha-1> <sha-2> <sha-3>           # Batch
 /cherry-pick <sha-1> <sha-2> --plan-only       # Plan without applying
-/cherry-pick <sha-1> <sha-2> --push            # Validate and push each successful cherry as it completes
+/cherry-pick <sha-1> <sha-2> --no-push         # Validate locally; stop with push recommendation
 ```
 
 ## Single Cherry-Pick Flow
 
-Each cherry-pick runs all validation phases. No validation phase may be skipped — the diff audit in step 7 is the only defense against scope leak (see gotchas.md). Step 7c runs only when the cherry terminates as `Blocked` or `Rejected`; it surfaces the upstream PRs that would unstick the row before the final report. Step 8 is a publish boundary: run it only when `--push` or explicit user authorization grants push permission.
+Each cherry-pick runs all validation phases. No validation phase may be skipped — the diff audit in step 7 is the only defense against scope leak (see gotchas.md). Step 7c runs only when the cherry terminates as `Blocked` or `Rejected`; it surfaces the upstream PRs that would unstick the row before the final report. Step 8 is a publish boundary: per-cherry push is the default; `--no-push` (or explicit user deferral during the run) records `pending-authorization` instead.
 
 ### 1. Investigate (heavy effort)
 
@@ -121,19 +121,17 @@ Mode is inform-only: surface candidates in the final report under "What to do ne
 
 → Full subagent contract, output block, future-auto-unblock notes: [references/unblock-discovery.md](references/unblock-discovery.md)
 
-### 8. Push Recommendation / Authorized Push
+### 8. Per-Cherry Push (default)
 
 ```bash
 git push
 ```
 
-When push is authorized, push **immediately after** step 7 passes for *this* cherry, before starting the next one. Do not batch pushes at the end of a multi-cherry run unless the user explicitly asked for batched push.
+Per-cherry push is the default. Immediately after step 7 passes for *this* cherry, the orchestrator pushes — before starting the next cherry. Do not batch pushes at the end of a multi-cherry run.
 
-When push is not authorized, stop before publishing and record `Push: pending authorization` in the execution table or `CHERRY_PICK.md`. Continue to independent planning/investigation work only if it does not depend on the unpublished cherry being on the remote.
+`--no-push` opts out: skip the `git push`, record `Push: pending authorization` in the execution table or `CHERRY_PICK.md`, and continue to independent planning/investigation work only if it does not depend on the unpublished cherry being on the remote.
 
-**Why:** CI can attribute each cherry independently only when each authorized push is per cherry. Batching defeats per-cherry attribution and forces bisection later.
-
-The only exception is when the user explicitly asks for batched push (e.g., to reduce CI cost). In that case, confirm before deferring and record the batched-push decision.
+**Why per-cherry, not batched:** CI can attribute each cherry independently only when each push is per cherry. Batching defeats per-cherry attribution and forces bisection later. The user may explicitly ask for batched push (e.g., to reduce CI cost) — confirm before deferring and record the batched-push decision.
 
 **Hard gate — per-cherry push boundary.** After step 7 passes and before any subsequent work runs (next cherry's investigate/apply, final report, checkpoint, or PR creation), the orchestrator must emit this confirmation block verbatim for *this* cherry:
 
@@ -145,7 +143,7 @@ Remote SHA: <sha visible on remote after push> | n/a
 Reason (if not pushed): <one line>
 ```
 
-If `Status: pushed`, the `git push` for this cherry has already happened — not queued, not deferred. If `Status: pending-authorization` or `deferred-by-user`, the orchestrator must also stop dependent follow-ups until the user clears the boundary. Do not start the next dependent cherry's worker without this block in chat for the previous cherry. This is the only structural defense against falling into the "apply, validate, next, …, done, push" rhythm that batches authorized pushes (see gotchas.md, "Authorized push batched at end instead of per-cherry").
+If `Status: pushed`, the `git push` for this cherry has already happened — not queued, not deferred. If `Status: pending-authorization` (only when `--no-push` is set) or `deferred-by-user`, the orchestrator must also stop dependent follow-ups until the user clears the boundary. Do not start the next dependent cherry's worker without this block in chat for the previous cherry. This is the only structural defense against falling into the "apply, validate, next, …, done, push" rhythm that batches pushes (see gotchas.md, "Push batched at end instead of per-cherry").
 
 ## Batch Cherry-Pick Flow
 
@@ -229,7 +227,7 @@ No full diffs or long logs unless blocked. If a blocked handoff needs raw eviden
    - TRIVIAL independent rows may use Standard-tier workers. Applying workers must use isolated worktrees/branches or return patch-only output; short-lived sessions are acceptable only for investigation, gating, planning, or status synthesis that does not mutate the checkout.
    - NON-TRIVIAL, conflict-prone, dependency-chain, or shared-file rows use Heavy-tier handling and usually run one at a time.
    - Headless workers are allowed only for TRIVIAL, independent rows with a tight contract such as [references/headless-trivial.md](references/headless-trivial.md). Treat this as an opt-in execution mode until validated on one cherry in the repo.
-3. **Per-cherry execution** — for each cherry in sequence, run the full single flow through validation in an isolated context. **Step 8 is a push boundary:** when authorized, the orchestrator performs the final shared-branch push per cherry; when unauthorized, record `pending authorization` and stop before publishing dependent work.
+3. **Per-cherry execution** — for each cherry in sequence, run the full single flow through validation in an isolated context. **Step 8 is a push boundary:** by default the orchestrator performs the final shared-branch push per cherry; under `--no-push` it records `pending authorization` and stops before publishing dependent work.
    - If a worker returns a prepared commit, branch, or patch from an isolated context, the orchestrator must replay it onto the current live target branch in planned order.
    - After replay, rerun the mandatory scope-leak audit and the minimum assigned validation on the live target branch before marking the row `Applied` or pushing.
    - Worker validation is useful evidence, but it is stale once fan-in happens; live-branch replay validation is the gate.

--- a/skills/cherry-pick/examples/final-report.md
+++ b/skills/cherry-pick/examples/final-report.md
@@ -7,6 +7,7 @@ Use this format at the end of every cherry-pick (single or batch). Lead with the
 - The compact 6-column table replaces the full 13-column execution table only in the final report. See [execution-table.md](execution-table.md) for the full table.
 - Add **Detailed Notes** for any row that is not `Applied` with `None` adaptation, plus any `Applied` row with notable adaptation.
 - Keep the dependency graph from the batch-sequence phase if inter-change dependencies were detected.
+- For every `Blocked` or `Rejected` row, include the unblock-discovery result (step 7c) — either the candidate PR list or "no unblock path: <reason>". A bare "skipped because X" is not enough; the user needs to know what would make this cherry-pickable.
 - "What to do next" is actionable only — no recap of what just happened.
 - Lead with the ticket outcome. The user cares about "is the fix on the branch" more than about the process.
 - **Scope Audit field is mandatory** for any row not in `Rejected` or `Skipped` — its absence means the leak-detection subagent did not run, which blocks `Applied`/`Partial`/`Blocked` status.
@@ -34,9 +35,11 @@ Use this format at the end of every cherry-pick (single or batch). Lead with the
 - **Adaptation details**: [What was modified and why]
 - **What was dropped**: [specific functions, files, or sub-fixes omitted]
 - **Residual risk**: [What remains uncertain]
+- **Unblock path** (Blocked/Rejected rows only): "Could cherry if we first apply: #X, #Y, #Z" — or "no unblock path: <one-line reason>"
 
 ### What to do next
 - [Actionable residual items — e.g., "encoding bug likely affects target via different code path — needs separate fix"]
 - [Validation gaps — e.g., "run pytest tests/unit_tests/mcp_service/ before merging"]
 - [Pending PRs to monitor — e.g., "#38676 still open — pick when merged"]
+- [Unblock candidates from step 7c — e.g., "PR #39501 introduced StructuredContentStripper; #39636 wired it into middleware. Pick both first, then re-run /cherry-pick #39798."]
 ```

--- a/skills/cherry-pick/gotchas.md
+++ b/skills/cherry-pick/gotchas.md
@@ -96,7 +96,7 @@ Format per entry: **Symptom** → **Why** → **Do instead** → **First seen**.
 
 **Why:** `git push` happening once per batch is the natural rhythm when you're orchestrating a tight loop ("apply, validate, next, …, done, push"). When push has been authorized, the per-cherry push directive is easy to skim past because it sits as a trailing note after the validate references rather than as a numbered phase, and the Batch Flow section doesn't restate it.
 
-**Do instead:** Step 8 is a numbered push boundary. If push is authorized, it runs **per cherry, before starting the next dependent one**. If push is not authorized, stop with `Push: pending authorization`. Only batch pushes when the user explicitly requests it (e.g., to reduce CI cost) — confirm first.
+**Do instead:** Step 8 is a numbered push boundary with an inline hard gate — the orchestrator must emit a `## Push Boundary — <pr-or-sha>` confirmation block (see SKILL.md step 8) before any subsequent work runs. If push is authorized, it runs **per cherry, before starting the next dependent one**. If push is not authorized, stop with `Status: pending-authorization`. Only batch pushes when the user explicitly requests it (e.g., to reduce CI cost) — confirm first.
 
 **First seen:** 4-PR batch into 6.0-release, 2026-05-06. Pushed once at the end; user flagged it.
 

--- a/skills/cherry-pick/gotchas.md
+++ b/skills/cherry-pick/gotchas.md
@@ -90,13 +90,13 @@ Format per entry: **Symptom** → **Why** → **Do instead** → **First seen**.
 
 ---
 
-## Authorized push batched at end instead of per-cherry
+## Push batched at end instead of per-cherry
 
-**Symptom:** Push was authorized for a multi-PR batch, but all cherry-picks get committed locally and pushed in a single `git push` at the end. CI runs once against the bundle. If a later cherry breaks something, the failure can't be attributed without bisecting the bundled push.
+**Symptom:** All cherry-picks in a multi-PR batch get committed locally and pushed in a single `git push` at the end. CI runs once against the bundle. If a later cherry breaks something, the failure can't be attributed without bisecting the bundled push.
 
-**Why:** `git push` happening once per batch is the natural rhythm when you're orchestrating a tight loop ("apply, validate, next, …, done, push"). When push has been authorized, the per-cherry push directive is easy to skim past because it sits as a trailing note after the validate references rather than as a numbered phase, and the Batch Flow section doesn't restate it.
+**Why:** `git push` happening once per batch is the natural rhythm when you're orchestrating a tight loop ("apply, validate, next, …, done, push"). Even with per-cherry push as the default, the per-cherry directive is easy to skim past because it sits as a trailing step after the validate references rather than as a numbered phase, and the Batch Flow section doesn't restate it.
 
-**Do instead:** Step 8 is a numbered push boundary with an inline hard gate — the orchestrator must emit a `## Push Boundary — <pr-or-sha>` confirmation block (see SKILL.md step 8) before any subsequent work runs. If push is authorized, it runs **per cherry, before starting the next dependent one**. If push is not authorized, stop with `Status: pending-authorization`. Only batch pushes when the user explicitly requests it (e.g., to reduce CI cost) — confirm first.
+**Do instead:** Step 8 is a numbered push boundary with an inline hard gate — the orchestrator must emit a `## Push Boundary — <pr-or-sha>` confirmation block (see SKILL.md step 8) before any subsequent work runs. Default behavior: push runs **per cherry, before starting the next dependent one**, and the block records `Status: pushed`. Under `--no-push`, stop with `Status: pending-authorization` instead. Only batch pushes when the user explicitly requests it (e.g., to reduce CI cost) — confirm first.
 
 **First seen:** 4-PR batch into 6.0-release, 2026-05-06. Pushed once at the end; user flagged it.
 

--- a/skills/cherry-pick/gotchas.md
+++ b/skills/cherry-pick/gotchas.md
@@ -132,3 +132,17 @@ If tests existed and weren't run, flag the gap explicitly with what was availabl
 **Remediation if already pushed:** Reset to before the bad commit, re-run `git cherry-pick -x` properly, then re-cherry-pick (or `rebase --onto`) any subsequent commits onto the corrected base, then `git push --force-with-lease`. Do not just amend the message — that leaves the wrong author.
 
 **First seen:** 2026-05-08 batch into 6.0-release. Partial cherry-pick of PR #39636 used `git format-patch | git apply` per the subagent prompt I wrote; landed with author=Joe Li (should have been Amin Ghadersohi) and a modified subject `(partial)`. User flagged; remediation required reset + redo + force-push of 5 commits.
+
+---
+
+## Blocked cherry reported with no path to unstick
+
+**Symptom:** Cherry terminates `Blocked` (modify/delete because target lacks the touched file, or a prerequisite commit isn't on target) or `Rejected` (architecture missing). The final report says "skipped because file X doesn't exist on target" and stops there. The user has to manually go figure out which upstream PRs would make the cherry applicable.
+
+**Why:** The investigation phase notes prerequisite commits and missing target-side modules in its raw signals, but nothing in the flow turns that into "you need PRs A, B, C to unstick this." The skill terminates the row and moves on. The orchestrator-as-thin-thing pattern bakes in early termination on `Blocked`/`Rejected` without giving the user a forward path.
+
+**Do instead:** Step 7c (Unblock Discovery) runs for every `Blocked`/`Rejected` row whose blocker looks like "target is missing something" — modify/delete, missing prereq, missing architecture. A discovery subagent (Standard tier by default) maps the missing files/symbols/prereqs to upstream PRs that introduced them, filters to those merged on source but not on target, and returns an ordered "apply these first" list. Result lands in `CHERRY_PICK.md` under the row's Subagent Handoff `Unblock candidates` field and in the Final Report under "What to do next" as "Could cherry if we first apply: #X, #Y, #Z." Inform-only for now — auto-prepending the candidates to the active wave is a future `--auto-unblock` extension. See [references/unblock-discovery.md](references/unblock-discovery.md).
+
+**Skip 7c** when the rejection is intrinsic (reject-category API rewrite, dependency bump, build-system change). Record "no unblock path" with the one-line reason and move on.
+
+**First seen:** 2026-05-21, user flagged the gap during workflow review — blocked cherries were terminating without forward path; user explicitly asked for inform-only first, auto-pick later.

--- a/skills/cherry-pick/references/headless-trivial.md
+++ b/skills/cherry-pick/references/headless-trivial.md
@@ -31,7 +31,7 @@ The worker may not report `Result: Applied` unless scope-audit evidence is prese
 - per-hunk audit verdict summary
 - final `LEAK / CLEAN / ESCALATE` recommendation
 
-Headless success is a candidate result, not final shared-branch success. The orchestrator must apply the worker's resulting commit or patch onto the live target branch in planned order, rerun the mandatory scope audit and minimum assigned validation on that live branch, then perform any authorized push itself.
+Headless success is a candidate result, not final shared-branch success. The orchestrator must apply the worker's resulting commit or patch onto the live target branch in planned order, rerun the mandatory scope audit and minimum assigned validation on that live branch, then perform any authorized push itself and emit the `## Push Boundary — <pr-or-sha>` block (see SKILL.md step 8) **before** dispatching the next headless worker.
 
 ## Status Block
 

--- a/skills/cherry-pick/references/headless-trivial.md
+++ b/skills/cherry-pick/references/headless-trivial.md
@@ -31,7 +31,7 @@ The worker may not report `Result: Applied` unless scope-audit evidence is prese
 - per-hunk audit verdict summary
 - final `LEAK / CLEAN / ESCALATE` recommendation
 
-Headless success is a candidate result, not final shared-branch success. The orchestrator must apply the worker's resulting commit or patch onto the live target branch in planned order, rerun the mandatory scope audit and minimum assigned validation on that live branch, then perform any authorized push itself and emit the `## Push Boundary — <pr-or-sha>` block (see SKILL.md step 8) **before** dispatching the next headless worker.
+Headless success is a candidate result, not final shared-branch success. The orchestrator must apply the worker's resulting commit or patch onto the live target branch in planned order, rerun the mandatory scope audit and minimum assigned validation on that live branch, then perform the per-cherry push itself (or, under `--no-push`, record `pending-authorization`) and emit the `## Push Boundary — <pr-or-sha>` block (see SKILL.md step 8) **before** dispatching the next headless worker.
 
 ## Status Block
 

--- a/skills/cherry-pick/references/unblock-discovery.md
+++ b/skills/cherry-pick/references/unblock-discovery.md
@@ -1,0 +1,71 @@
+# Unblock Discovery
+
+When a cherry-pick terminates as `Blocked` or `Rejected`, the orchestrator must not let it die in the report with "skipped because X." Run an unblock-discovery subagent to identify the **specific upstream PRs/commits that, if cherry-picked first, would unstick this change**, and surface them in the final report.
+
+Mode is **inform-only** by default. The subagent does not investigate, gate, plan, or apply the candidate dependencies — it only names them. Auto-picking is a future extension.
+
+## When to Run
+
+Run for every row whose terminal `Result` is `Blocked` or `Rejected`, including:
+- Modify/delete because target lacks files the source touched
+- Prerequisite commits flagged during investigate but not present on target
+- Reject-category change where the rejection is "architecture missing on target" rather than "wrong shape of change" (e.g., feature depends on a refactor that hasn't shipped)
+- Conflict resolution escalated past adapt because target diverged structurally
+
+**Skip** when the rejection is intrinsic — e.g., behavior-changing API rewrite that should never be cherry-picked at all, dependency-bump PR, build-system change. There's no "add prerequisite X" that makes a reject-category cherry safe; record "no unblock path" and move on.
+
+## Subagent Contract
+
+The subagent runs in an isolated context. Tier: **Standard** by default; **Heavy** if investigation produced a long prerequisite list or the blocker spans multiple modules.
+
+### Inputs
+
+Provide the worker with:
+- Source SHA and PR
+- Target branch
+- Investigation output (especially "Raw Signals for Gate" — modify/delete files, prerequisite commits, target-side missing modules)
+- Result label and blocker reason (one line)
+- The execution-table row's `Notes`
+
+Do NOT pass full diffs or raw logs — the subagent works from the structured signals.
+
+### Steps
+
+1. For each missing file/module/API the investigation flagged on the target:
+   - `git log --all --source --oneline -- <path>` on the source branch (or repo-wide) to identify the commit(s) that introduced or last touched it relevantly.
+   - `gh pr list --search "<file-or-symbol>" --state merged --limit 10` and `gh search prs "<symbol>" --merged` to surface candidate PRs.
+2. For each prerequisite commit flagged during investigate, resolve the owning PR via `gh pr list --search <sha>` or `git log --grep <sha>`.
+3. Filter candidates: keep only those that are (a) merged into the source branch, (b) not already on the target branch (`git log <target> --grep "cherry picked from commit <sha>"` returns nothing), and (c) plausibly self-contained enough to cherry-pick (use commit message + file count as a cheap heuristic).
+4. For each surviving candidate, write one line: `#<pr> "<title>" — unblocks <reason>`.
+
+### Output
+
+Return exactly this block. No diffs, no logs.
+
+```markdown
+## Unblock Discovery — <pr-or-sha>
+Blocker: <one-line reason>
+Unblock path: yes | no | unclear
+
+### Candidates (order matters: apply first → last)
+1. #<pr> `<source-sha>` — <title>. Unblocks: <which file/symbol/prereq this introduces>.
+2. #<pr> `<source-sha>` — <title>. Unblocks: <…>.
+
+### Notes
+<one paragraph max — caveats, ordering risks, "candidate #2 is itself a feature change and may not be safe to cherry">
+```
+
+If `Unblock path: no`, state why in one line (e.g., "blocker is API rewrite touching 40+ files; no single prerequisite would unstick it").
+
+If `Unblock path: unclear`, list whatever partial signal exists and flag that a deeper investigation is needed.
+
+## Orchestrator Responsibilities
+
+- Insert the discovery block into `CHERRY_PICK.md` under the row's Subagent Handoff entry (field `Unblock candidates`).
+- Carry the candidate list into the Final Report under **What to do next** as: "Could cherry `<pr-or-sha>` if we first apply: #X, #Y, #Z."
+- Do **not** automatically queue the candidates for cherry-pick. The user decides whether to add them to the run.
+- If the user accepts the candidates, re-enter the batch flow with the new PRs prepended to the wave that contains the blocked row.
+
+## Future Extension (Auto-Unblock)
+
+When `--auto-unblock` is added: the orchestrator may, with user pre-authorization, prepend the candidate list to the active wave and re-run from sequence planning. Until then, this skill stays inform-only — the surface area for "we cherry-picked the wrong dependency and made things worse" is too large to fire silently.

--- a/skills/cherry-pick/references/validate.md
+++ b/skills/cherry-pick/references/validate.md
@@ -126,7 +126,7 @@ git commit --amend --no-edit
 
 **Pre-existing failures on unrelated files** (warnings on files the cherry-pick didn't touch) are out of scope — note them in the validation summary but do not attempt to fix them within the cherry-pick.
 
-The validation amend stays local since publishing is gated on `--push` or explicit user authorization. Do not push, then amend, then force-push, when amending pre-push would have worked.
+The validation amend must complete **before** the per-cherry push in step 8. Push is the default at step 8; if you push first and then amend, you have to force-push to publish the fix — which the workflow forbids. Always: validate → fix → amend → emit Push Boundary → push.
 
 ## Minimum Validation Bar
 

--- a/skills/cherry-pick/templates/cherry-pick-manifest.md
+++ b/skills/cherry-pick/templates/cherry-pick-manifest.md
@@ -50,3 +50,4 @@ Next action:
 - Commands run:
 - Residual risk:
 - Dependency implications:
+- Unblock candidates (Blocked/Rejected only):

--- a/skills/debug/references/ci-fix-orchestration.md
+++ b/skills/debug/references/ci-fix-orchestration.md
@@ -74,7 +74,7 @@ Keep scope limited to the failing surface. If verification is weak or root cause
 
 ## Commit Recommendation Strategy
 
-This section recommends the shape of the git action; it does not grant permission to mutate history or publish changes. Commit, amend, rebase, push, force-push, GitHub posting, and thread resolution require explicit user authorization or a command flag that clearly grants that exact boundary.
+For STRONG-verified trivial/moderate fixes with a clean Review Gate, the default flow creates a new commit on the current feature branch and pushes it. Amend, rebase, and force-push still require explicit user authorization for this run, and the push target must be the current feature branch on the expected remote. PARTIAL/WEAK verification and standard-path holds stay non-committing.
 
 | Scenario | Action |
 |----------|--------|

--- a/skills/feedback/references/fix-review.md
+++ b/skills/feedback/references/fix-review.md
@@ -35,7 +35,7 @@ For truly minimal edits, such as typo fixes or mechanical renames, review may be
 
 Prefer fixing the originating in-PR commit when the branch is not merged and the source commit is clear.
 
-This section recommends a git shape only. Do not commit, amend, rebase, push, or force-push unless the user explicitly authorized that exact boundary for this feedback round. `--auto` may skip triage or posting confirmations, but it does not authorize git history mutation by itself.
+New commits on the current PR branch and pushes are part of the default `/address-feedback` flow — apply the recommended shape and push once verification is clean. Amend, rebase, and force-push still require explicit user authorization for this feedback round (`--auto` does not grant history mutation by itself).
 
 | Scenario | Action |
 |----------|--------|

--- a/skills/feedback/references/reply-resolve.md
+++ b/skills/feedback/references/reply-resolve.md
@@ -64,14 +64,21 @@ If `gh` is authenticated as a teammate or automation account that could surprise
 - Human reviewer threads stay open. Post the reply and let the reviewer resolve or re-review.
 - Never resolve ambiguous or discussion threads unless the user explicitly asks.
 
-## Push + Post Gate
+## Push + Post Defaults
 
-Do not push, post GitHub replies, approve/request changes, or resolve threads unless the user explicitly authorized that boundary or a command flag clearly grants it.
+Default behavior: push new commits on the current PR branch, post replies to bot threads, and resolve eligible bot threads once the underlying fix is verified. Approve / request-changes always confirms with the user.
 
-Boundary meanings:
+Pause for explicit confirmation when:
+- a human-thread reply needs user wording
+- the next git step would amend, rebase, or force-push history
+- the push target is ambiguous (not the current PR branch, or tracks an unexpected remote)
+- the next action would approve or request changes on the PR
+- verification failed or the fix is not yet on the PR branch
+
+Flag meanings:
 - `--draft`: never post or resolve; return reply drafts and resolution recommendations only.
-- `--auto`: may skip posting confirmation for already-verified replies, but does not authorize commit, amend, rebase, push, or force-push by itself.
-- No flag: prepare replies and ask before posting or resolving.
+- `--auto`: skip the per-step posting confirmation for verified bot threads and the push announcement. Does NOT authorize amend, rebase, or force-push.
+- No flag: push the new commit, then announce the post/resolve plan in one block and proceed unless the user objects.
 
 Replies that claim a fix was made should only be posted after the fix is visible on the PR branch, or after the user explicitly asks to post draft wording before pushing.
 


### PR DESCRIPTION
## Summary
- Cherry-pick now pushes per-cherry by default (was: validate-then-stop); `--no-push` restores the old behavior. Inline Push Boundary gate prevents end-of-run batch pushes.
- Work-producing commands (`/fix-bug`, `/create-feature`, `/create-pr`, `/review-pr`, `/test-pr`, `/create-tests`, `/update-tests`, `/run-test-plan`) must write a PROJECT.md entry before the chat summary, so `/clear` or `/archive-project-file` immediately after a TRIVIAL/MODERATE run no longer loses the result.
- New `hooks/pre-push-validate.sh` runs the repo's pinned `pre-commit` hooks on changed files at push time (240s timeout, `SKIP_PRECHECK=1` bypass, ruff fallback when no `.pre-commit-config.yaml`).

## Changes

**Cherry-pick workflow** (`skills/cherry-pick/`)
- Step 8: per-cherry push as default; `--no-push` opts out
- Inline Push Boundary hard gate (named confirmation block) prevents the "apply, validate, …, batch push at end" rhythm
- Step 7c: surface upstream PRs that would unblock Blocked/Rejected rows in the final report (inform-only)

**Workflow defaults — feedback + CI** (`commands/address-feedback.md`, `commands/fix-ci.md`, `skills/feedback/`)
- Restore action-first commit/push: new commits on the feature/PR branch push automatically once verified; bot-thread replies/resolutions proceed automatically
- Pause cases tightened to amend, rebase, force-push, ambiguous push target, human-thread wording, approve/request-changes, or PARTIAL/WEAK verification

**PROJECT.md durability gates** (`commands/fix-bug.md`, `commands/create-feature.md`, `commands/create-pr.md`, `commands/review-pr.md`, `commands/test-pr.md`, `commands/create-tests.md`, `commands/update-tests.md`, `commands/run-test-plan.md`)
- Hard-gate PROJECT.md entry + confirmation block before the chat summary in every work-producing command
- TRIVIAL/MODERATE runs satisfy the gate with a single end-of-run rollup; STANDARD cadence unchanged

**Pre-push validation hook** (`hooks/pre-push-validate.sh`, `README.md`)
- Delegates to `pre-commit run --files <changed>` so the hook picks up whatever the repo configured (ruff, mypy, prettier, oxlint, eslint, tsc, custom rules)
- Falls back to ruff via repo `.venv`/uv when no `.pre-commit-config.yaml`
- README updated to list the hook and clarify `test-prevent-project-commit.sh` is a smoke test

**Other**
- `/review-pr`: PII scrub gate over drafted findings, top-level comments, and review summaries
- Universal rule + `/start`: document `readlink -f` workaround for Write/Edit refusing to write through symlinks (hits `.claudette`/worktree setups)

## Test plan
- [ ] `bash -n hooks/pre-push-validate.sh` (syntax)
- [ ] Dry-run pre-push hook on a repo with `.pre-commit-config.yaml`: confirm it filters to changed files
- [ ] Dry-run pre-push hook on a repo without `.pre-commit-config.yaml`: confirm ruff fallback fires
- [ ] Run `/fix-bug` on a TRIVIAL bug; confirm PROJECT.md rollup appears before chat summary
- [ ] Run `/cherry-pick` on a single PR; confirm push happens per-cherry and Push Boundary block emits
- [ ] Run `/cherry-pick --no-push` and confirm validate-then-stop behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)