### PR TITLE
fix: Report routed provider failure diagnostics

### DIFF
--- a/aitk/routing_transport.py
+++ b/aitk/routing_transport.py
@@ -37,6 +37,58 @@ from aitk.routing_closure import _contracts
 from aitk.routing_resolver import resolve_route
 
 
+_PROVIDER_DIAGNOSTIC_LIMIT = 1024
+
+
+def _structured_failure_diagnostic(stdout: str) -> str:
+    """Extract only an explicit provider error message from JSON output."""
+
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        failed = (
+            event_type == "error"
+            or (isinstance(event_type, str) and event_type.endswith(".failed"))
+            or event.get("is_error") is True
+            or event.get("subtype") == "error"
+        )
+        if not failed:
+            continue
+        error = event.get("error")
+        if isinstance(error, dict) and isinstance(error.get("message"), str):
+            return error["message"]
+        if isinstance(error, str):
+            return error
+        if isinstance(event.get("message"), str):
+            return event["message"]
+    return ""
+
+
+def _provider_failure_message(stderr: str, stdout: str) -> str:
+    """Return a bounded, one-line diagnostic for a failed provider process.
+
+    A nonzero CLI exit is still fail-closed, but the provider's stderr is often
+    the only indication whether the pinned selector, authentication, or a
+    required control was rejected. Keep that evidence in the structured error
+    without letting terminal control characters or an unbounded provider log
+    flood a workflow checkpoint or summary.
+    """
+
+    diagnostic = re.sub(r"\s+", " ", stderr).strip()
+    if not diagnostic:
+        diagnostic = _structured_failure_diagnostic(stdout)
+    if not diagnostic:
+        return "provider process failed"
+    if len(diagnostic) > _PROVIDER_DIAGNOSTIC_LIMIT:
+        diagnostic = diagnostic[:_PROVIDER_DIAGNOSTIC_LIMIT] + "… [truncated]"
+    return f"provider process failed: {diagnostic}"
+
+
 def worker_prompt(
     route: ResolvedRoute,
     prompt: str,
@@ -553,7 +605,7 @@ def run_model(
                 exit_code=process.returncode,
                 argv=None,
                 result=None,
-                error="provider process failed",
+                error=_provider_failure_message(process.stderr, process.stdout),
             )
         try:
             if provider == "codex":

--- a/tests/test_routing_transport.py
+++ b/tests/test_routing_transport.py
@@ -877,6 +877,100 @@ class RoutingTransportTests(RoutingTestCase):
                     payload["transport"],
                 )
                 self.assertEqual("MODEL_ROUTE_UNAVAILABLE", payload["error"]["code"])
+                if failure == "nonzero":
+                    self.assertEqual(
+                        "provider process failed: rejected",
+                        payload["error"]["message"],
+                    )
+
+    def test_provider_failure_diagnostic_is_bounded(self) -> None:
+        def runner(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            if "--version" in argv:
+                return subprocess.CompletedProcess(argv, 0, "2.1.214\n", "")
+            if "--help" in argv:
+                flags = " ".join(
+                    (
+                        "--print --no-session-persistence --safe-mode ",
+                        "--strict-mcp-config --mcp-config --model --effort ",
+                        "--permission-mode --json-schema --output-format ",
+                        "--disallowedTools --tools",
+                    )
+                )
+                return subprocess.CompletedProcess(argv, 0, flags, "")
+            return subprocess.CompletedProcess(argv, 1, "", "x" * 5000)
+
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as prompt:
+            prompt.write("Review this change.")
+            prompt.flush()
+            with mock.patch(
+                "aitk.routing_transport.shutil.which", return_value="/bin/claude"
+            ):
+                code, payload = run_model(
+                    ROOT,
+                    "review",
+                    "claude",
+                    "review.code-quality-final",
+                    Path(prompt.name),
+                    cwd=ROOT,
+                    runner=runner,
+                )
+
+        self.assertEqual(3, code)
+        self.assertEqual("MODEL_ROUTE_UNAVAILABLE", payload["error"]["code"])
+        self.assertTrue(payload["error"]["message"].endswith("… [truncated]"))
+        self.assertLessEqual(len(payload["error"]["message"]), 1100)
+
+    def test_provider_failure_uses_a_structured_error_event_when_stderr_is_empty(
+        self,
+    ) -> None:
+        def runner(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            if "--version" in argv:
+                return subprocess.CompletedProcess(argv, 0, "2.1.214\n", "")
+            if "--help" in argv:
+                flags = " ".join(
+                    (
+                        "--print --no-session-persistence --safe-mode ",
+                        "--strict-mcp-config --mcp-config --model --effort ",
+                        "--permission-mode --json-schema --output-format ",
+                        "--disallowedTools --tools",
+                    )
+                )
+                return subprocess.CompletedProcess(argv, 0, flags, "")
+            return subprocess.CompletedProcess(
+                argv,
+                1,
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "error",
+                        "is_error": True,
+                        "error": {"message": "selected model is unavailable"},
+                    }
+                ),
+                "",
+            )
+
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as prompt:
+            prompt.write("Review this change.")
+            prompt.flush()
+            with mock.patch(
+                "aitk.routing_transport.shutil.which", return_value="/bin/claude"
+            ):
+                code, payload = run_model(
+                    ROOT,
+                    "review",
+                    "claude",
+                    "review.code-quality-final",
+                    Path(prompt.name),
+                    cwd=ROOT,
+                    runner=runner,
+                )
+
+        self.assertEqual(3, code)
+        self.assertEqual(
+            "provider process failed: selected model is unavailable",
+            payload["error"]["message"],
+        )
 
     def test_invalid_prompt_is_rejected_before_provider_preflight(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- Preserve provider failure diagnostics when a routed review cannot start.
- Surface bounded stderr or an explicit structured failure event instead of only `provider process failed`.

## Incident Root Cause

The routing transport discarded provider diagnostics after a nonzero CLI exit, leaving `MODEL_ROUTE_UNAVAILABLE` without actionable cause details.

## Fix

- Normalize and bound stderr diagnostics to 1,024 characters.
- Fall back only to messages from explicit structured failure events, never arbitrary provider output.
- Add regression coverage for both paths and truncation.

## Test plan

- `PYTHONPATH=. python3 tests/test_routing_transport.py`
- `bin/aitk check`
- `git diff --check`

## Review status

Independent routed review could not run because both configured provider routes returned `MODEL_ROUTE_UNAVAILABLE`.